### PR TITLE
Email language detection

### DIFF
--- a/mailcom/parse.py
+++ b/mailcom/parse.py
@@ -104,6 +104,8 @@ class Pseudonymize:
         return text_as_sents
 
     def get_ner(self, sentence):
+        if not hasattr(self, "ner_recognizer"):
+            self.init_transformers()
         ner = self.ner_recognizer(sentence)
         return ner
 
@@ -248,7 +250,6 @@ if __name__ == "__main__":
     pseudonymizer = Pseudonymize()
     pseudonymizer.init_spacy("fr")
     # the above init now needs to move to after detect language
-    pseudonymizer.init_transformers()
     for idx, email in enumerate(io.get_email_list()):
         if not email["content"]:
             continue

--- a/mailcom/parse.py
+++ b/mailcom/parse.py
@@ -2,7 +2,7 @@ import spacy as sp
 from transformers import pipeline
 from pathlib import Path
 from mailcom.inout import InoutHandler
-from mailcom.utils import check_dir, make_dir
+from mailcom.utils import check_dir, make_dir, LangDetector
 
 # please modify this section depending on your setup
 # input language - either "es" or "fr"

--- a/mailcom/parse.py
+++ b/mailcom/parse.py
@@ -1,4 +1,3 @@
-import os
 import spacy as sp
 from transformers import pipeline
 from pathlib import Path

--- a/mailcom/parse.py
+++ b/mailcom/parse.py
@@ -2,7 +2,7 @@ import spacy as sp
 from transformers import pipeline
 from pathlib import Path
 from mailcom.inout import InoutHandler
-from mailcom.utils import check_dir, make_dir, LangDetector
+from mailcom.utils import check_dir, make_dir
 
 # please modify this section depending on your setup
 # input language - either "es" or "fr"

--- a/mailcom/parse.py
+++ b/mailcom/parse.py
@@ -10,7 +10,6 @@ from mailcom.utils import check_dir, make_dir, LangDetector
 lang = "es"
 # lang = "fr"
 # path where the input files can be found
-# path_input = Path("./mailcom/test/data/")
 path_input = Path("./data/in/")
 # path where the output files should be written to
 # this is generated if not present yet
@@ -135,8 +134,6 @@ class Pseudonymize:
             # if none is found, choose a new pseudonym
             if pseudonym == "":
                 try:
-                    # TODO: clean up the below comment after addressing the question
-                    # question: is the new pseudonym always a France one?
                     pseudonym = self.pseudo_first_names["fr"][
                         n_pseudonyms_used
                     ]  # reaches end of the list
@@ -255,24 +252,9 @@ if __name__ == "__main__":
     for idx, email in enumerate(io.get_email_list()):
         if not email["content"]:
             continue
-        # mabe here the stripping of dates and email addresses should take place
-        # and of unnecessary punctuation
-        # to get more accurate language detection
-        text = pseudonymizer.pseudonymize_email_addresses(text)
         # detect and set the language of the text
         lang_detector = LangDetector()
         language = lang_detector.get_detections(text=text)
-        print(
-            "langdetect: detected [(language, probability)] {} in email {}".format(
-                language, file
-            )
-        )
-        language = lang_detector.get_detections(text=text, lang_lib="langid")
-        print(
-            "langid: detected [(language, probability)] {} in email {}".format(
-                language, file
-            )
-        )
         # here we would now set the spacy language and download model if required
         # Test functionality of Pseudonymize class
         _ = pseudonymizer.pseudonymize(email)

--- a/mailcom/parse.py
+++ b/mailcom/parse.py
@@ -3,7 +3,7 @@ import spacy as sp
 from transformers import pipeline
 from pathlib import Path
 from mailcom.inout import InoutHandler
-from mailcom.utils import check_dir, make_dir
+from mailcom.utils import check_dir, make_dir, LangDetector
 
 # please modify this section depending on your setup
 # input language - either "es" or "fr"

--- a/mailcom/parse.py
+++ b/mailcom/parse.py
@@ -114,7 +114,7 @@ class Pseudonymize:
         used_pseudonyms = [
             ne["pseudonym"] if "pseudonym" in ne else "" for ne in self.ne_list
         ]
-        # amount of pseudonyms for PER used
+        # amount of pseudonyms for PER used (PER for "PERSON")
         n_pseudonyms_used = [ne["entity_group"] for ne in self.ne_list].count("PER")
         # check all variations of the name
         name_variations = [
@@ -134,6 +134,8 @@ class Pseudonymize:
             # if none is found, choose a new pseudonym
             if pseudonym == "":
                 try:
+                    # TODO: clean up the below comment after addressing the question
+                    # question: is the new pseudonym always a France one?
                     pseudonym = self.pseudo_first_names["fr"][
                         n_pseudonyms_used
                     ]  # reaches end of the list

--- a/mailcom/parse.py
+++ b/mailcom/parse.py
@@ -2,7 +2,7 @@ import spacy as sp
 from transformers import pipeline
 from pathlib import Path
 from mailcom.inout import InoutHandler
-from mailcom.utils import check_dir, make_dir, LangDetector
+from mailcom.utils import check_dir, make_dir
 
 # please modify this section depending on your setup
 # input language - either "es" or "fr"
@@ -252,10 +252,6 @@ if __name__ == "__main__":
     for idx, email in enumerate(io.get_email_list()):
         if not email["content"]:
             continue
-        # detect and set the language of the text
-        lang_detector = LangDetector()
-        language = lang_detector.get_detections(text=text)
-        # here we would now set the spacy language and download model if required
         # Test functionality of Pseudonymize class
         _ = pseudonymizer.pseudonymize(email)
         print("New text:", email["pseudo_content"])

--- a/mailcom/parse.py
+++ b/mailcom/parse.py
@@ -3,6 +3,7 @@ import spacy as sp
 from transformers import pipeline
 from pathlib import Path
 from mailcom.inout import InoutHandler
+from mailcom.utils import check_dir, make_dir
 
 # please modify this section depending on your setup
 # input language - either "es" or "fr"
@@ -232,18 +233,6 @@ class Pseudonymize:
             pseudonymized_sentences.append(ps_sent)
         email["pseudo_content"] = self.concatenate(pseudonymized_sentences)
         return email["pseudo_content"]
-
-
-def check_dir(path: str) -> bool:
-    if not os.path.exists(path):
-        raise OSError("Path {} does not exist".format(path))
-    else:
-        return True
-
-
-def make_dir(path: str):
-    # make directory at path
-    os.makedirs(path + "/")
 
 
 if __name__ == "__main__":

--- a/mailcom/parse.py
+++ b/mailcom/parse.py
@@ -10,7 +10,8 @@ from mailcom.utils import check_dir, make_dir
 lang = "es"
 # lang = "fr"
 # path where the input files can be found
-path_input = Path("./mailcom/test/data/")
+# path_input = Path("./mailcom/test/data/")
+path_input = Path("./data/in/")
 # path where the output files should be written to
 # this is generated if not present yet
 path_output = Path("./data/out/")
@@ -235,13 +236,9 @@ class Pseudonymize:
 
 
 if __name__ == "__main__":
-    # nlp_spacy = init_spacy(lang)
-    # nlp_transformers = init_transformers()
-
     # check that input dir is there
     if not check_dir(path_input):
         raise ValueError("Could not find input directory with eml files! Aborting ...")
-
     # check that the output dir is there, if not generate
     if not check_dir(path_output):
         print("Generating output directory/ies.")
@@ -253,10 +250,30 @@ if __name__ == "__main__":
     # html_files = list_of_files(path_input, "html")
     pseudonymizer = Pseudonymize()
     pseudonymizer.init_spacy("fr")
+    # the above init now needs to move to after detect language
     pseudonymizer.init_transformers()
     for idx, email in enumerate(io.get_email_list()):
         if not email["content"]:
             continue
+        # mabe here the stripping of dates and email addresses should take place
+        # and of unnecessary punctuation
+        # to get more accurate language detection
+        text = pseudonymizer.pseudonymize_email_addresses(text)
+        # detect and set the language of the text
+        lang_detector = LangDetector()
+        language = lang_detector.get_detections(text=text)
+        print(
+            "langdetect: detected [(language, probability)] {} in email {}".format(
+                language, file
+            )
+        )
+        language = lang_detector.get_detections(text=text, lang_lib="langid")
+        print(
+            "langid: detected [(language, probability)] {} in email {}".format(
+                language, file
+            )
+        )
+        # here we would now set the spacy language and download model if required
         # Test functionality of Pseudonymize class
         _ = pseudonymizer.pseudonymize(email)
         print("New text:", email["pseudo_content"])

--- a/mailcom/test/test_utils.py
+++ b/mailcom/test/test_utils.py
@@ -212,6 +212,12 @@ def test_get_detections(get_lang_detector):
     assert detection_langid[0][0] == lang_samples[sentence]
 
 
+def test_get_detections_fail(get_lang_detector):
+    sentence = list(lang_samples.keys())[0]
+    with pytest.raises(ValueError):
+        get_lang_detector.get_detections(sentence, "not_a_lib")
+
+
 def test_detect_lang_sentences(get_lang_detector, get_mixed_lang_docs):
     for lang_lib in ["langid", "langdetect"]:
         for doc in get_mixed_lang_docs:

--- a/mailcom/test/test_utils.py
+++ b/mailcom/test/test_utils.py
@@ -1,0 +1,27 @@
+from mailcom import utils
+import pytest
+
+
+# these worked when we were using strings
+# with the update to Path, we need to change the tests
+def test_check_dir(tmpdir):
+    mydir = tmpdir.mkdir("sub")
+    assert utils.check_dir(str(mydir))
+    with pytest.raises(OSError):
+        utils.check_dir(str(tmpdir.join("sub2")))
+
+
+def test_make_dir(tmpdir):
+    mydir = tmpdir.join("sub")
+    utils.make_dir(str(mydir))
+    assert mydir.check()
+
+
+def test_check_dir_fail():
+    with pytest.raises(OSError):
+        utils.check_dir(str("mydir"))
+
+
+@pytest.fixture()
+def get_lang_detector():
+    return utils.LangDetector()

--- a/mailcom/test/test_utils.py
+++ b/mailcom/test/test_utils.py
@@ -49,6 +49,21 @@ langid_langs = ['af', 'am', 'an', 'ar', 'as', 'az',
                     'zh', 'zu']
 
 
+lang_samples = [
+    "J'espère que tu vas bien! Je voulais partager avec toi quelques photos de mon dernier voyage!",
+    "Hola, ¿cómo estás? Espero que estés bien. ¡Hasta pronto!",
+    "Bonjour, comment ça va? J'espère que tu vas bien. À bientôt!",
+    "Hello, how are you? I hope you are well. See you soon!",
+    "Hallo, wie geht es dir? Ich hoffe, es geht dir gut. Bis bald!",
+    "Ciao, come stai? Spero che tu stia bene. A presto!",
+    "Olá, como você está? Espero que você esteja bem. Até logo!",
+    "Привет, как дела? Надеюсь, у тебя все хорошо. Увидимся скоро!",
+    "你好，你好吗？希望你一切都好。很快见到你！",
+    "こんにちは、元気ですか？ あなたが元気であることを願っています。 またね！",
+    "안녕하세요, 어떻게 지내세요? 잘 지내길 바랍니다. 곧 뵙겠습니다!",
+]
+
+
 @pytest.fixture()
 def get_lang_detector():
     return utils.LangDetector()
@@ -80,3 +95,25 @@ def test_constrain_langid_fail(get_lang_detector):
     lang_set = ["not_a_language"]
     with pytest.raises(ValueError):
         get_lang_detector.constrain_langid(lang_set)
+
+
+def test_determine_langdetect(get_lang_detector):
+    get_lang_detector.determine_langdetect()
+    probs = []
+    for i in range(10):
+        _, prob = get_lang_detector.detect_with_langdetect(lang_samples[0])
+        probs.append(prob)
+    assert len(set(probs)) == 1
+
+
+def test_detect_with_langid(get_lang_detector):
+    lang, prob = get_lang_detector.detect_with_langid(lang_samples[0])
+    assert lang == "fr"
+    assert prob > 0.9
+
+
+def test_detect_with_langdetect(get_lang_detector):
+    get_lang_detector.determine_langdetect()
+    lang, prob = get_lang_detector.detect_with_langdetect(lang_samples[0])
+    assert lang == "fr"
+    assert prob > 0.9

--- a/mailcom/test/test_utils.py
+++ b/mailcom/test/test_utils.py
@@ -49,19 +49,23 @@ langid_langs = ['af', 'am', 'an', 'ar', 'as', 'az',
                     'zh', 'zu']
 
 
-lang_samples = [
-    "J'espère que tu vas bien! Je voulais partager avec toi quelques photos de mon dernier voyage!",
-    "Hola, ¿cómo estás? Espero que estés bien. ¡Hasta pronto!",
-    "Bonjour, comment ça va? J'espère que tu vas bien. À bientôt!",
-    "Hello, how are you? I hope you are well. See you soon!",
-    "Hallo, wie geht es dir? Ich hoffe, es geht dir gut. Bis bald!",
-    "Ciao, come stai? Spero che tu stia bene. A presto!",
-    "Olá, como você está? Espero que você esteja bem. Até logo!",
-    "Привет, как дела? Надеюсь, у тебя все хорошо. Увидимся скоро!",
-    "你好，你好吗？希望你一切都好。很快见到你！",
-    "こんにちは、元気ですか？ あなたが元気であることを願っています。 またね！",
-    "안녕하세요, 어떻게 지내세요? 잘 지내길 바랍니다. 곧 뵙겠습니다!",
-]
+lang_samples = {
+    "J'espère que tu vas bien! Je voulais partager avec toi quelques photos de mon dernier voyage!": "fr",
+    "Hola, ¿cómo estás? Espero que estés bien. ¡Hasta pronto!": "es",
+    "Hello, how are you? I hope you are well. See you soon!": "en",
+    "Hallo, wie geht es dir? Ich hoffe, es geht dir gut. Bis bald!": "de",
+    "Ciao, come stai? Spero che tu stia bene. A presto!": "it",
+    "Olá, como você está? Espero que você esteja bem. Até logo!": "pt",
+    "Привет, как дела? Надеюсь, у тебя все хорошо. Увидимся скоро!": "ru",
+    "你好，你好吗？希望你一切都好。很快见到你！": "zh",
+    "こんにちは、元気ですか？ あなたが元気であることを願っています。 またね！": "ja",
+    "안녕하세요, 어떻게 지내세요? 잘 지내길 바랍니다. 곧 뵙겠습니다!": "ko",
+    "مرحبًا، كيف حالك؟ آمل أن تكون بخير. أراك قريبًا!": "ar",
+    "नमस्ते, कैसे हो? आशा है कि आप ठीक होंगे। जल्द ही मिलेंगे!": "hi",
+}
+
+
+detect_threshold = 0.7
 
 
 @pytest.fixture()
@@ -101,19 +105,24 @@ def test_determine_langdetect(get_lang_detector):
     get_lang_detector.determine_langdetect()
     probs = []
     for i in range(10):
-        _, prob = get_lang_detector.detect_with_langdetect(lang_samples[0])
+        detection = get_lang_detector.detect_with_langdetect(list(lang_samples.keys())[0])
+        _, prob = detection[0]
         probs.append(prob)
     assert len(set(probs)) == 1
 
 
-def test_detect_with_langid(get_lang_detector):
-    lang, prob = get_lang_detector.detect_with_langid(lang_samples[0])
-    assert lang == "fr"
-    assert prob > 0.9
+def test_detect_singe_lang_with_langid(get_lang_detector):
+    for sent, lang in lang_samples.items():
+        detection = get_lang_detector.detect_with_langid(sent)
+        lang, prob = detection[0]
+        assert lang == lang
+        assert prob > detect_threshold
 
 
-def test_detect_with_langdetect(get_lang_detector):
+def test_detect_single_lang_with_langdetect(get_lang_detector):
     get_lang_detector.determine_langdetect()
-    lang, prob = get_lang_detector.detect_with_langdetect(lang_samples[0])
-    assert lang == "fr"
-    assert prob > 0.9
+    for sent, lang in lang_samples.items():
+        detection = get_lang_detector.detect_with_langdetect(sent)
+        lang, prob = detection[0]
+        assert lang == lang
+        assert prob > detect_threshold

--- a/mailcom/test/test_utils.py
+++ b/mailcom/test/test_utils.py
@@ -22,6 +22,61 @@ def test_check_dir_fail():
         utils.check_dir(str("mydir"))
 
 
+langid_langs = ['af', 'am', 'an', 'ar', 'as', 'az', 
+                    'be', 'bg', 'bn', 'br', 'bs', 
+                    'ca', 'cs', 'cy', 
+                    'da', 'de', 'dz', 
+                    'el', 'en', 'eo', 'es', 'et', 'eu', 
+                    'fa', 'fi', 'fo', 'fr', 
+                    'ga', 'gl', 'gu', 
+                    'he', 'hi', 'hr', 'ht', 'hu', 'hy', 
+                    'id', 'is', 'it', 
+                    'ja', 'jv', 
+                    'ka', 'kk', 'km', 'kn', 'ko', 'ku', 'ky', 
+                    'la', 'lb', 'lo', 'lt', 'lv', 
+                    'mg', 'mk', 'ml', 'mn', 'mr', 'ms', 'mt', 
+                    'nb', 'ne', 'nl', 'nn', 'no', 
+                    'oc', 'or', 
+                    'pa', 'pl', 'ps', 'pt', 
+                    'qu', 
+                    'ro', 'ru', 'rw', 
+                    'se', 'si', 'sk', 'sl', 'sq', 'sr', 'sv', 'sw', 
+                    'ta', 'te', 'th', 'tl', 'tr', 
+                    'ug', 'uk', 'ur', 
+                    'vi', 'vo', 
+                    'wa', 
+                    'xh', 
+                    'zh', 'zu']
+
+
 @pytest.fixture()
 def get_lang_detector():
     return utils.LangDetector()
+
+
+def test_lang_detector(get_lang_detector):
+    assert get_lang_detector.lang_id.nb_classes == langid_langs
+
+
+def test_constrain_langid(get_lang_detector):
+    lang_set = ["es", "fr"]
+    get_lang_detector.constrain_langid(lang_set)
+    assert get_lang_detector.lang_id.nb_classes == lang_set
+
+
+def test_constrain_langid_empty(get_lang_detector):
+    lang_set = []
+    get_lang_detector.constrain_langid(lang_set)
+    assert get_lang_detector.lang_id.nb_classes == langid_langs
+
+
+def test_constrain_langid_intersec(get_lang_detector):
+    lang_set = ["es", "fr", "not_a_language"]
+    get_lang_detector.constrain_langid(lang_set)
+    assert get_lang_detector.lang_id.nb_classes == ["es", "fr"]
+
+
+def test_constrain_langid_fail(get_lang_detector):
+    lang_set = ["not_a_language"]
+    with pytest.raises(ValueError):
+        get_lang_detector.constrain_langid(lang_set)

--- a/mailcom/test/test_utils.py
+++ b/mailcom/test/test_utils.py
@@ -24,31 +24,105 @@ def test_check_dir_fail():
 
 
 # test cases for email language detection
-langid_langs = ['af', 'am', 'an', 'ar', 'as', 'az', 
-                    'be', 'bg', 'bn', 'br', 'bs', 
-                    'ca', 'cs', 'cy', 
-                    'da', 'de', 'dz', 
-                    'el', 'en', 'eo', 'es', 'et', 'eu', 
-                    'fa', 'fi', 'fo', 'fr', 
-                    'ga', 'gl', 'gu', 
-                    'he', 'hi', 'hr', 'ht', 'hu', 'hy', 
-                    'id', 'is', 'it', 
-                    'ja', 'jv', 
-                    'ka', 'kk', 'km', 'kn', 'ko', 'ku', 'ky', 
-                    'la', 'lb', 'lo', 'lt', 'lv', 
-                    'mg', 'mk', 'ml', 'mn', 'mr', 'ms', 'mt', 
-                    'nb', 'ne', 'nl', 'nn', 'no', 
-                    'oc', 'or', 
-                    'pa', 'pl', 'ps', 'pt', 
-                    'qu', 
-                    'ro', 'ru', 'rw', 
-                    'se', 'si', 'sk', 'sl', 'sq', 'sr', 'sv', 'sw', 
-                    'ta', 'te', 'th', 'tl', 'tr', 
-                    'ug', 'uk', 'ur', 
-                    'vi', 'vo', 
-                    'wa', 
-                    'xh', 
-                    'zh', 'zu']
+langid_langs = [
+    "af",
+    "am",
+    "an",
+    "ar",
+    "as",
+    "az",
+    "be",
+    "bg",
+    "bn",
+    "br",
+    "bs",
+    "ca",
+    "cs",
+    "cy",
+    "da",
+    "de",
+    "dz",
+    "el",
+    "en",
+    "eo",
+    "es",
+    "et",
+    "eu",
+    "fa",
+    "fi",
+    "fo",
+    "fr",
+    "ga",
+    "gl",
+    "gu",
+    "he",
+    "hi",
+    "hr",
+    "ht",
+    "hu",
+    "hy",
+    "id",
+    "is",
+    "it",
+    "ja",
+    "jv",
+    "ka",
+    "kk",
+    "km",
+    "kn",
+    "ko",
+    "ku",
+    "ky",
+    "la",
+    "lb",
+    "lo",
+    "lt",
+    "lv",
+    "mg",
+    "mk",
+    "ml",
+    "mn",
+    "mr",
+    "ms",
+    "mt",
+    "nb",
+    "ne",
+    "nl",
+    "nn",
+    "no",
+    "oc",
+    "or",
+    "pa",
+    "pl",
+    "ps",
+    "pt",
+    "qu",
+    "ro",
+    "ru",
+    "rw",
+    "se",
+    "si",
+    "sk",
+    "sl",
+    "sq",
+    "sr",
+    "sv",
+    "sw",
+    "ta",
+    "te",
+    "th",
+    "tl",
+    "tr",
+    "ug",
+    "uk",
+    "ur",
+    "vi",
+    "vo",
+    "wa",
+    "xh",
+    "zh",
+    "zu",
+]
 lang_samples = {
     "J'espère que tu vas bien! Je voulais partager avec toi quelques photos de mon dernier voyage!": "fr",
     "Hola, ¿cómo estás? Espero que estés bien. ¡Hasta pronto!": "es",
@@ -67,7 +141,7 @@ punctuations_as_str = "".join(punctuation)
 single_detect_threshold = 0.7
 multi_detect_threshold = 0.4
 repeat_num = 5
-lang_num = 2 # tested up to 3 languages
+lang_num = 2  # tested up to 3 languages
 
 
 @pytest.fixture()
@@ -79,14 +153,14 @@ def get_lang_detector():
 def get_mixed_lang_docs():
     docs = {}
     sentences = list(lang_samples.keys())
-    for i in range(len(sentences)-(lang_num-1)):
+    for i in range(len(sentences) - (lang_num - 1)):
         # create a text with sentences in lang_num different languages,
         # each sentence is repeated repeat_num times before the next sentence is added
         tmp_sentences = []
         tmp_lang = []
         for j in range(lang_num):
-            tmp_sentences += [sentences[i+j]] * repeat_num + ["\n"]
-            tmp_lang.append(lang_samples[sentences[i+j]])
+            tmp_sentences += [sentences[i + j]] * repeat_num + ["\n"]
+            tmp_lang.append(lang_samples[sentences[i + j]])
         text = " ".join(tmp_sentences)
         docs[text] = tmp_lang
 
@@ -99,7 +173,10 @@ def test_contains_only_punctuations(get_lang_detector):
     assert get_lang_detector.contains_only_punctuations(".,;:!? ") is True
     assert get_lang_detector.contains_only_punctuations(".,;:!? a") is False
     assert get_lang_detector.contains_only_punctuations(punctuations_as_str) is True
-    assert get_lang_detector.contains_only_punctuations(punctuations_as_str + "a sentence") is False
+    assert (
+        get_lang_detector.contains_only_punctuations(punctuations_as_str + "a sentence")
+        is False
+    )
 
 
 def test_strip_punctuations(get_lang_detector):
@@ -108,7 +185,10 @@ def test_strip_punctuations(get_lang_detector):
     assert get_lang_detector.strip_punctuations(".,;:!? ") == " "
     assert get_lang_detector.strip_punctuations(".,;:!? a") == " a"
     assert get_lang_detector.strip_punctuations(punctuations_as_str) == ""
-    assert get_lang_detector.strip_punctuations(punctuations_as_str + "\n a sentence") == "\n a sentence"
+    assert (
+        get_lang_detector.strip_punctuations(punctuations_as_str + "\n a sentence")
+        == "\n a sentence"
+    )
 
 
 def test_contains_only_numbers(get_lang_detector):
@@ -116,14 +196,24 @@ def test_contains_only_numbers(get_lang_detector):
     assert get_lang_detector.contains_only_numbers("1234567890a") is False
     assert get_lang_detector.contains_only_numbers("1234567890 ") is True
     assert get_lang_detector.contains_only_numbers("1234567890 a") is False
-    assert get_lang_detector.contains_only_numbers("1234567890" + punctuations_as_str) is True
-    assert get_lang_detector.contains_only_numbers("1234567890" + punctuations_as_str + "a sentence") is False
+    assert (
+        get_lang_detector.contains_only_numbers("1234567890" + punctuations_as_str)
+        is True
+    )
+    assert (
+        get_lang_detector.contains_only_numbers(
+            "1234567890" + punctuations_as_str + "a sentence"
+        )
+        is False
+    )
 
 
 def test_contains_only_emails(get_lang_detector):
     assert get_lang_detector.contains_only_emails("abc@gmail.com") is True
     assert get_lang_detector.contains_only_emails("<abc@gmail.com>") is True
-    assert get_lang_detector.contains_only_emails("abc@gmail.com \n cdf@gmail.com") is True
+    assert (
+        get_lang_detector.contains_only_emails("abc@gmail.com \n cdf@gmail.com") is True
+    )
     assert get_lang_detector.contains_only_emails("Sent from abc@gmail.com") is False
 
 
@@ -159,7 +249,9 @@ def test_determine_langdetect(get_lang_detector):
     get_lang_detector.determine_langdetect()
     probs = []
     for i in range(10):
-        detection = get_lang_detector.detect_with_langdetect(list(lang_samples.keys())[0])
+        detection = get_lang_detector.detect_with_langdetect(
+            list(lang_samples.keys())[0]
+        )
         _, prob = detection[0]
         probs.append(prob)
     assert len(set(probs)) == 1
@@ -209,7 +301,13 @@ def test_detect_mixed_lang_with_langid(get_lang_detector, get_mixed_lang_docs):
     for doc in get_mixed_lang_docs:
         detection = get_lang_detector.detect_with_langid(doc)
         det_lang, prob = detection[0]
-        if (lang_num == 2) and get_mixed_lang_docs[doc][0] in ["en", "it", "pt", "zh", "ar"]:
+        if (lang_num == 2) and get_mixed_lang_docs[doc][0] in [
+            "en",
+            "it",
+            "pt",
+            "zh",
+            "ar",
+        ]:
             # detected lang is the second one in the doc
             assert det_lang == get_mixed_lang_docs[doc][1]
             assert prob > multi_detect_threshold
@@ -217,7 +315,12 @@ def test_detect_mixed_lang_with_langid(get_lang_detector, get_mixed_lang_docs):
             # detected lang is the second one in the doc
             assert det_lang == get_mixed_lang_docs[doc][1]
             assert prob > multi_detect_threshold
-        elif (lang_num == 3) and get_mixed_lang_docs[doc][0] in ["de", "it", "pt", "ru"]:
+        elif (lang_num == 3) and get_mixed_lang_docs[doc][0] in [
+            "de",
+            "it",
+            "pt",
+            "ru",
+        ]:
             # detected lang is completely wrong
             with pytest.raises(AssertionError):
                 assert det_lang == get_mixed_lang_docs[doc][0]
@@ -322,5 +425,9 @@ def test_detect_lang_sentences(get_lang_detector, get_mixed_lang_docs):
             assert lang_tree.begin() == 0
             assert lang_tree.end() == len(doc.split("\n"))
             for i, interval in enumerate(sorted(lang_tree.items())):
-                detected_lang = interval.data.split("-")[0] if lang_lib == "langdetect" else interval.data
+                detected_lang = (
+                    interval.data.split("-")[0]
+                    if lang_lib == "langdetect"
+                    else interval.data
+                )
                 assert detected_lang == get_mixed_lang_docs[doc][i]

--- a/mailcom/test/test_utils.py
+++ b/mailcom/test/test_utils.py
@@ -1,3 +1,4 @@
+import math
 from mailcom import utils
 import pytest
 from string import punctuation
@@ -124,7 +125,8 @@ langid_langs = [
     "zu",
 ]
 lang_samples = {
-    "J'espère que tu vas bien! Je voulais partager avec toi quelques photos de mon dernier voyage!": "fr",
+    "J'espère que tu vas bien! "
+    "Je voulais partager avec toi quelques photos de mon dernier voyage!": "fr",
     "Hola, ¿cómo estás? Espero que estés bien. ¡Hasta pronto!": "es",
     "Hello, how are you? I hope you are well. See you soon!": "en",
     "Hallo, wie geht es dir? Ich hoffe, es geht dir gut. Bis bald!": "de",
@@ -377,8 +379,8 @@ def test_get_detections_empty(get_lang_detector):
     detection_langdetect = get_lang_detector.get_detections(sentence, "langdetect")
     assert detection_langid[0][0] == detection_langdetect[0][0]
     assert detection_langid[0][0] is None
-    assert detection_langid[0][1] == 0.0
-    assert detection_langdetect[0][1] == 0.0
+    assert math.isclose(detection_langid[0][1], 0.0)
+    assert math.isclose(detection_langdetect[0][1], 0.0)
 
 
 def test_get_detections_only_punctuations(get_lang_detector):
@@ -387,8 +389,8 @@ def test_get_detections_only_punctuations(get_lang_detector):
     detection_langdetect = get_lang_detector.get_detections(sentence, "langdetect")
     assert detection_langid[0][0] == detection_langdetect[0][0]
     assert detection_langid[0][0] is None
-    assert detection_langid[0][1] == 0.0
-    assert detection_langdetect[0][1] == 0.0
+    assert math.isclose(detection_langid[0][1], 0.0)
+    assert math.isclose(detection_langdetect[0][1], 0.0)
 
 
 def test_get_detections_only_numbers(get_lang_detector):
@@ -397,8 +399,8 @@ def test_get_detections_only_numbers(get_lang_detector):
     detection_langdetect = get_lang_detector.get_detections(sentence, "langdetect")
     assert detection_langid[0][0] == detection_langdetect[0][0]
     assert detection_langid[0][0] is None
-    assert detection_langid[0][1] == 0.0
-    assert detection_langdetect[0][1] == 0.0
+    assert math.isclose(detection_langid[0][1], 0.0)
+    assert math.isclose(detection_langdetect[0][1], 0.0)
 
 
 def test_get_detections_only_emails(get_lang_detector):
@@ -407,8 +409,8 @@ def test_get_detections_only_emails(get_lang_detector):
     detection_langdetect = get_lang_detector.get_detections(sentence, "langdetect")
     assert detection_langid[0][0] == detection_langdetect[0][0]
     assert detection_langid[0][0] is None
-    assert detection_langid[0][1] == 0.0
-    assert detection_langdetect[0][1] == 0.0
+    assert math.isclose(detection_langid[0][1], 0.0)
+    assert math.isclose(detection_langdetect[0][1], 0.0)
 
 
 def test_get_detections_fail(get_lang_detector):

--- a/mailcom/test/test_utils.py
+++ b/mailcom/test/test_utils.py
@@ -4,24 +4,22 @@ import pytest
 from string import punctuation
 
 
-# these worked when we were using strings
-# with the update to Path, we need to change the tests
 def test_check_dir(tmpdir):
     mydir = tmpdir.mkdir("sub")
-    assert utils.check_dir(str(mydir))
+    assert utils.check_dir(mydir)
     with pytest.raises(OSError):
-        utils.check_dir(str(tmpdir.join("sub2")))
+        utils.check_dir(tmpdir.join("sub2"))
 
 
 def test_make_dir(tmpdir):
     mydir = tmpdir.join("sub")
-    utils.make_dir(str(mydir))
+    utils.make_dir(mydir)
     assert mydir.check()
 
 
 def test_check_dir_fail():
     with pytest.raises(OSError):
-        utils.check_dir(str("mydir"))
+        utils.check_dir("mydir")
 
 
 # test cases for email language detection
@@ -277,10 +275,9 @@ def test_constrain_langid_fail(get_lang_detector):
 def test_determine_langdetect(get_lang_detector):
     get_lang_detector.determine_langdetect()
     probs = []
-    for i in range(10):
-        detection = get_lang_detector.detect_with_langdetect(
-            list(lang_samples.keys())[0]
-        )
+    for _ in range(10):
+        sample_text = list(lang_samples.keys())[0]
+        detection = get_lang_detector.detect_with_langdetect(sample_text)
         _, prob = detection[0]
         probs.append(prob)
     assert len(set(probs)) == 1
@@ -298,6 +295,12 @@ def test_detect_single_lang_with_transformers(get_lang_det_w_init):
         else:
             assert det_lang == lang
             assert prob > single_detect_threshold
+
+
+def test_detect_single_lang_with_transformers_no_init(get_lang_detector):
+    # check that the transformers model is initialized if not explicitly done
+    get_lang_detector.detect_with_transformers("This is a test.")
+    assert get_lang_detector.lang_detector_trans
 
 
 def test_detect_singe_lang_with_langid(get_lang_detector):

--- a/mailcom/test/test_utils.py
+++ b/mailcom/test/test_utils.py
@@ -173,6 +173,26 @@ def test_detect_singe_lang_with_langid(get_lang_detector):
         assert prob > single_detect_threshold
 
 
+def test_detect_single_lang_with_langid_error(get_lang_detector):
+    with pytest.raises(ValueError):
+        get_lang_detector.detect_with_langid(None)
+
+
+def test_detect_single_lang_with_langdetect_error(get_lang_detector):
+    with pytest.raises(ValueError):
+        get_lang_detector.detect_with_langdetect(None)
+    with pytest.raises(ValueError):
+        get_lang_detector.detect_with_langdetect("")
+    with pytest.raises(ValueError):
+        get_lang_detector.detect_with_langdetect(" \n\n")
+    with pytest.raises(ValueError):
+        get_lang_detector.detect_with_langdetect(".,;:!?")
+    with pytest.raises(ValueError):
+        get_lang_detector.detect_with_langdetect("1234567890")
+    with pytest.raises(ValueError):
+        get_lang_detector.detect_with_langdetect("<abc@gmail.com>")
+
+
 def test_detect_single_lang_with_langdetect(get_lang_detector):
     get_lang_detector.determine_langdetect()
     for sent, lang in lang_samples.items():

--- a/mailcom/utils.py
+++ b/mailcom/utils.py
@@ -164,17 +164,14 @@ class LangDetector:
         current_lang = ""
         for sent in sentences:
             if sent:
-                try:
-                    detections = self.get_detections(sent, lang_lib)
-                    # only take the first detection
-                    lang, _ = detections[0]
-                    if lang != current_lang:
-                        if current_lang:
-                            result_tree.addi(marked_idx, current_idx, current_lang)
-                            marked_idx = current_idx
-                        current_lang = lang
-                except Exception as e:
-                    raise ValueError("Error in detecting sentence {}: Error: {}".format(sent, e))
+                detections = self.get_detections(sent, lang_lib)
+                # only take the first detection
+                lang, _ = detections[0]
+                if lang != current_lang:
+                    if current_lang:
+                        result_tree.addi(marked_idx, current_idx, current_lang)
+                        marked_idx = current_idx
+                    current_lang = lang
             current_idx += 1
 
         result_tree.addi(marked_idx, current_idx, current_lang)

--- a/mailcom/utils.py
+++ b/mailcom/utils.py
@@ -273,8 +273,7 @@ if __name__ == "__main__":
 
     results = []
 
-    for idx, email_path in enumerate(zip(io.get_email_list(), io.email_path_list)):
-        email, path = email_path
+    for email, path in zip(io.get_email_list(), io.email_path_list):
         if not email["content"]:
             continue
         file_results = {"file": str(path.name)}

--- a/mailcom/utils.py
+++ b/mailcom/utils.py
@@ -269,14 +269,17 @@ if __name__ == "__main__":
     # process the text
     io = InoutHandler(path_input)
     io.list_of_files()
+    io.process_emails()
 
     results = []
 
-    for file in io.email_list:
-        file_results = {"file": str(file.name)}
-        print("Parsing input file {}".format(file))
-        text = io.get_text(file)
-        text = io.get_html_text(text)
+    for idx, email_path in enumerate(zip(io.get_email_list(), io.email_path_list)):
+        email, path = email_path
+        if not email["content"]:
+            continue
+        file_results = {"file": str(path.name)}
+        print("Parsing input file {}".format(path.name))
+        text = email["content"]
 
         # Test functionality of LangDetector class in utils.py
         lang_detector = LangDetector()

--- a/mailcom/utils.py
+++ b/mailcom/utils.py
@@ -8,15 +8,27 @@ from mailcom.inout import InoutHandler
 import pandas as pd
 
 
-def check_dir(path: str) -> bool:
+def check_dir(path: Path) -> bool:
+    """Check if a directory exists at a given path.
+
+    Args:
+        path (pathlib.Path)): The path to check.
+
+    Returns:
+        bool: True if the directory exists, False otherwise.
+    """
     if not os.path.exists(path):
         raise OSError("Path {} does not exist".format(path))
     else:
         return True
 
 
-def make_dir(path: str):
-    # make directory at path
+def make_dir(path: Path) -> None:
+    """Make a directory at a given path.
+
+    Args:
+        path (pathlib.Path): The path to make a directory at.
+    """
     os.makedirs(path + "/")
 
 
@@ -117,6 +129,10 @@ class LangDetector:
         Returns:
             list(str, float): The possible language and their probabilities.
         """
+        # checking for attribute first instead of catching exception
+        # to avoid repetition of code
+        if not hasattr(self, "lang_detector_trans"):
+            self.init_transformers()
         detections = self.lang_detector_trans(sentence, top_k=2, truncation=True)
         results = []
         for detection in detections:
@@ -165,13 +181,14 @@ class LangDetector:
             )
         return results
 
-    def get_detections(self, text: str, lang_lib="trans") -> list[tuple[str, float]]:
+    def get_detections(self, text: str, lang_lib="langid") -> list[tuple[str, float]]:
         """Get detections for a given text using a specified lang_lib or model.
 
         Args:
             text (str): The text to detect the language of.
             lang_lib (str): The lang_lib to use for detection.
-                Options are "langid" and "langdetect".
+                Options are "langid", "langdetect" and "trans".
+                The default is "langid".
 
         Returns:
             list(str, float): A list of detected languages and their probabilities.
@@ -195,20 +212,20 @@ class LangDetector:
                 return self.detect_with_transformers(text)
             else:
                 raise ValueError(
-                    "Language library must be either 'langid' or 'langdetect'."
+                    "Language library must be either 'langid', 'langdetect' or 'trans'."
                 )
         else:
             return [(None, 0.0)]
 
     def detect_lang_sentences(
-        self, sentences: list[str], lang_lib="trans"
+        self, sentences: list[str], lang_lib="langid"
     ) -> IntervalTree:
         """Detect languages of a list of sentences using a specified language library.
 
         Args:
             sentences (str): The document to detect the languages of.
             lang_lib (str): The lang_lib to use for detection.
-                Options are "langid" and "langdetect".
+                Options are "langid", "langdetect" and "trans".
 
         Returns:
             IntervalTree: An interval tree with the detected languages and their spans.

--- a/mailcom/utils.py
+++ b/mailcom/utils.py
@@ -1,5 +1,4 @@
 import os
-import langid
 from langid.langid import LanguageIdentifier, model
 from langdetect import detect_langs, DetectorFactory
 
@@ -45,11 +44,10 @@ class LangDetector:
             text (str): The text to detect the language of.
 
         Returns:
-            lang (str): The detected language.
-            prob (float): The probability of the detection.
+            [(str, float)]: The detected language and its probability.
         """
         lang, prob = self.lang_id.classify(text)
-        return lang, prob
+        return [(lang, prob)]
     
     def detect_with_langdetect(self, text: str):
         """Dectect language of a given text using langdetect library.
@@ -61,4 +59,5 @@ class LangDetector:
             list(str, float): The possible language and their probabilities.
         """
         detections = self.detect_langs(text)
-        return detections[0].lang, detections[0].prob
+        results = [(det.lang, det.prob) for det in detections]
+        return results

--- a/mailcom/utils.py
+++ b/mailcom/utils.py
@@ -60,4 +60,5 @@ class LangDetector:
         Returns:
             list(str, float): The possible language and their probabilities.
         """
-        return detect_langs(text)
+        detections = self.detect_langs(text)
+        return detections[0].lang, detections[0].prob

--- a/mailcom/utils.py
+++ b/mailcom/utils.py
@@ -33,7 +33,7 @@ class LangDetector:
                     "No languages in the set are supported by langid. Please check the language set."
                 )
     
-    def determ_langdetect(self):
+    def determine_langdetect(self):
         """Enforce consistent results for langdetect.
         """
         DetectorFactory.seed = 0

--- a/mailcom/utils.py
+++ b/mailcom/utils.py
@@ -72,14 +72,16 @@ class LangDetector:
         return all("@" in word for word in text_as_list)
 
     def constrain_langid(self, lang_set=[]):
-        """Set constraint for language set of langid. Default is no constrained languages."""
+        """Set constraint for language set of langid.
+        Default is no constrained languages."""
         if lang_set:
             lang_intersec = list(set(lang_set) & set(self.lang_id.nb_classes))
             if lang_intersec:
                 self.lang_id.set_languages(lang_intersec)
             else:
                 raise ValueError(
-                    "No languages in the set are supported by langid. Please check the language set."
+                    "No languages in the set are supported by langid. "
+                    "Please check the language set."
                 )
 
     def determine_langdetect(self):
@@ -133,12 +135,15 @@ class LangDetector:
 
         Args:
             text (str): The text to detect the language of.
-            lang_lib (str): The lang_lib to use for detection. Options are "langid" and "langdetect".
+            lang_lib (str): The lang_lib to use for detection.
+                Options are "langid" and "langdetect".
 
         Returns:
             list(str, float): A list of detected languages and their probabilities.
         """
-        # make sure that the text is not empty, not just whitespace or newline, not only contains punctuations
+        # make sure that the text is not empty,
+        # not just whitespace or newline,
+        # not only contains punctuations
         if (
             text.strip().strip("\n")
             and not self.contains_only_punctuations(text)
@@ -164,7 +169,8 @@ class LangDetector:
 
         Args:
             sentences (str): The document to detect the languages of.
-            lang_lib (str): The lang_lib to use for detection. Options are "langid" and "langdetect".
+            lang_lib (str): The lang_lib to use for detection.
+                Options are "langid" and "langdetect".
 
         Returns:
             IntervalTree: An interval tree with the detected languages and their spans.

--- a/mailcom/utils.py
+++ b/mailcom/utils.py
@@ -31,7 +31,7 @@ class LangDetector:
             bool: True if the text is only punctuations, False otherwise.
         """
         return not any(char.isalnum() for char in text)
-    
+
     def strip_punctuations(self, text: str) -> str:
         """Strip punctuations from a given text.
 
@@ -42,7 +42,7 @@ class LangDetector:
             str: The text with punctuations stripped.
         """
         return "".join([char for char in text if char.isalnum() or char.isspace()])
-    
+
     def contains_only_numbers(self, text: str) -> bool:
         """Check if a given text contains only numbers.
 
@@ -53,9 +53,11 @@ class LangDetector:
             bool: True if the text is only numbers, False otherwise.
         """
         processed_text = self.strip_punctuations(text)
-        processed_text = "".join([char for char in processed_text if not char.isspace()])
+        processed_text = "".join(
+            [char for char in processed_text if not char.isspace()]
+        )
         return processed_text.isdigit()
-    
+
     def contains_only_emails(self, text: str) -> bool:
         """Check if a given text contains only email(s).
 
@@ -68,11 +70,9 @@ class LangDetector:
         processed_text = text.strip().strip("\n")
         text_as_list = [word for word in processed_text.split(" ") if word.strip()]
         return all("@" in word for word in text_as_list)
-        
 
     def constrain_langid(self, lang_set=[]):
-        """Set constraint for language set of langid. Default is no constrained languages.
-        """
+        """Set constraint for language set of langid. Default is no constrained languages."""
         if lang_set:
             lang_intersec = list(set(lang_set) & set(self.lang_id.nb_classes))
             if lang_intersec:
@@ -81,10 +81,9 @@ class LangDetector:
                 raise ValueError(
                     "No languages in the set are supported by langid. Please check the language set."
                 )
-    
+
     def determine_langdetect(self):
-        """Enforce consistent results for langdetect.
-        """
+        """Enforce consistent results for langdetect."""
         DetectorFactory.seed = 0
 
     def detect_with_langid(self, sentence: str) -> list[tuple[str, float]]:
@@ -100,11 +99,13 @@ class LangDetector:
         try:
             lang, prob = self.lang_id.classify(sentence)
         except Exception as e:
-            lang = None 
+            lang = None
             prob = 0.0
-            raise ValueError("Error in detecting sentence {}: Error: {}".format(sentence, e))
+            raise ValueError(
+                "Error in detecting sentence {}: Error: {}".format(sentence, e)
+            )
         return [(lang, prob)]
-    
+
     def detect_with_langdetect(self, sentence: str) -> list[tuple[str, float]]:
         """Dectect language of a given text using langdetect library.
         Recommended for a single language detection.
@@ -120,10 +121,14 @@ class LangDetector:
             results = [(det.lang, det.prob) for det in detections]
         except Exception as e:
             results = [(None, 0.0)]
-            raise ValueError("Error in detecting sentence {}: Error: {}".format(sentence, e))
+            raise ValueError(
+                "Error in detecting sentence {}: Error: {}".format(sentence, e)
+            )
         return results
-    
-    def get_detections(self, text: str, lang_lib="langdetect") -> list[tuple[str, float]]:
+
+    def get_detections(
+        self, text: str, lang_lib="langdetect"
+    ) -> list[tuple[str, float]]:
         """Get detections for a given text using a specified lang_lib.
 
         Args:
@@ -134,21 +139,27 @@ class LangDetector:
             list(str, float): A list of detected languages and their probabilities.
         """
         # make sure that the text is not empty, not just whitespace or newline, not only contains punctuations
-        if text.strip().strip("\n") \
-            and not self.contains_only_punctuations(text) \
-                and not self.contains_only_numbers(text) \
-                    and not self.contains_only_emails(text):
+        if (
+            text.strip().strip("\n")
+            and not self.contains_only_punctuations(text)
+            and not self.contains_only_numbers(text)
+            and not self.contains_only_emails(text)
+        ):
             if lang_lib == "langid":
                 return self.detect_with_langid(text)
             elif lang_lib == "langdetect":
                 self.determine_langdetect()
                 return self.detect_with_langdetect(text)
             else:
-                raise ValueError("Language library must be either 'langid' or 'langdetect'.")
+                raise ValueError(
+                    "Language library must be either 'langid' or 'langdetect'."
+                )
         else:
             return [(None, 0.0)]
-        
-    def detect_lang_sentences(self, sentences: list[str], lang_lib="langdetect") -> IntervalTree:
+
+    def detect_lang_sentences(
+        self, sentences: list[str], lang_lib="langdetect"
+    ) -> IntervalTree:
         """Detect languages of a list of sentences using a specified language library.
 
         Args:

--- a/mailcom/utils.py
+++ b/mailcom/utils.py
@@ -1,4 +1,7 @@
 import os
+import langid
+from langid.langid import LanguageIdentifier, model
+from langdetect import detect_langs, DetectorFactory
 
 
 def check_dir(path: str) -> bool:
@@ -11,3 +14,50 @@ def check_dir(path: str) -> bool:
 def make_dir(path: str):
     # make directory at path
     os.makedirs(path + "/")
+
+
+class LangDetector:
+    def __init__(self):
+        self.lang_id = LanguageIdentifier.from_modelstring(model, norm_probs=True)
+        self.detect_langs = detect_langs
+
+    def constrain_langid(self, lang_set=[]):
+        """Set constraint for language set of langid. Default is no constrained languages.
+        """
+        if lang_set:
+            lang_intersec = list(set(lang_set) & set(self.lang_id.nb_classes))
+            if lang_intersec:
+                self.lang_id.set_languages(lang_intersec)
+            else:
+                raise ValueError(
+                    "No languages in the set are supported by langid. Please check the language set."
+                )
+    
+    def determ_langdetect(self):
+        """Enforce consistent results for langdetect.
+        """
+        DetectorFactory.seed = 0
+
+    def detect_with_langid(self, text: str):
+        """Dectect language of a given text using langid library.
+
+        Args:
+            text (str): The text to detect the language of.
+
+        Returns:
+            lang (str): The detected language.
+            prob (float): The probability of the detection.
+        """
+        lang, prob = self.lang_id.classify(text)
+        return lang, prob
+    
+    def detect_with_langdetect(self, text: str):
+        """Dectect language of a given text using langdetect library.
+
+        Args:
+            text (str): The text to detect the language of.
+
+        Returns:
+            list(str, float): The possible language and their probabilities.
+        """
+        return detect_langs(text)

--- a/mailcom/utils.py
+++ b/mailcom/utils.py
@@ -1,0 +1,13 @@
+import os
+
+
+def check_dir(path: str) -> bool:
+    if not os.path.exists(path):
+        raise OSError("Path {} does not exist".format(path))
+    else:
+        return True
+
+
+def make_dir(path: str):
+    # make directory at path
+    os.makedirs(path + "/")

--- a/notebook/demo.ipynb
+++ b/notebook/demo.ipynb
@@ -27,6 +27,7 @@
    "source": [
     "import mailcom.inout\n",
     "import mailcom.parse\n",
+    "import mailcom.utils\n",
     "import pandas as pd\n",
     "from IPython.display import display, HTML"
    ]
@@ -112,6 +113,7 @@
     "transformers_model = \"xlm-roberta-large-finetuned-conll03-english\"\n",
     "# set the revision number for transformers, here using the default revision number\n",
     "transformers_revision_number = \"18f95e9\"\n",
+    "langdect = mailcom.utils.LangDetector()\n",
     "ps = mailcom.parse.Pseudonymize()\n",
     "ps.init_spacy(language=spacy_language, model=spacy_model)\n",
     "ps.init_transformers(model=transformers_model, model_revision_number=transformers_revision_number)"
@@ -138,6 +140,10 @@
     "    # the dict already has the entries content, date, attachments, attachment type\n",
     "    if not email[\"content\"]:\n",
     "        continue\n",
+    "    text = ps.pseudonymize_email_addresses(text)\n",
+    "    # detect the language\n",
+    "    languages = langdect.get_detections(text=text)\n",
+    "    print(\"Detected dominant language {} with probability {}\".format(languages[0][0], languages[0][1]))\n",
     "    # Test functionality of Pseudonymize class\n",
     "    # The output text is returned, as well as saved as a dict entry as \"pseudo_content\"\n",
     "    _ = ps.pseudonymize(email)\n",
@@ -204,7 +210,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/notebook/performance_demo.ipynb
+++ b/notebook/performance_demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,12 +11,13 @@
     "import pandas as pd\n",
     "import time\n",
     "import datetime\n",
-    "import matplotlib.pyplot as plt"
+    "import matplotlib.pyplot as plt\n",
+    "import mailcom.utils"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,12 +27,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 32,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     Unnamed: 0                                            message\n",
+      "0           242  Von meinem iPhone gesendet Anfang der weiterge...\n",
+      "1           243  Von meinem iPhone gesendet Anfang der weiterge...\n",
+      "2           244  Von meinem iPhone gesendet Anfang der weiterge...\n",
+      "3           245  Von meinem iPhone gesendet Anfang der weiterge...\n",
+      "4           246  Von meinem iPhone gesendet Anfang der weiterge...\n",
+      "..          ...                                                ...\n",
+      "98         1313  \\nVon: Mélissa des Presses de l'Université Lav...\n",
+      "99         1314  Von: Librairie Classiques Garnier &amp;lt;libr...\n",
+      "100        1315  La langue s'enrichit #36 - FranceTerme\\nProf. ...\n",
+      "101        1316  Activités de juin - Presses de l'Université La...\n",
+      "102        1317  Nouveautés de juin\\nProf. Dr. Sybille Große I ...\n",
+      "\n",
+      "[103 rows x 2 columns]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Some weights of the model checkpoint at xlm-roberta-large-finetuned-conll03-english were not used when initializing XLMRobertaForTokenClassification: ['roberta.pooler.dense.bias', 'roberta.pooler.dense.weight']\n",
+      "- This IS expected if you are initializing XLMRobertaForTokenClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
+      "- This IS NOT expected if you are initializing XLMRobertaForTokenClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
+      "Device set to use cuda:0\n",
+      "Device set to use cuda:0\n"
+     ]
+    }
+   ],
    "source": [
+    "out_file = \"../data/out/lang_detection_from_csv.csv\"\n",
     "# import files from csv file\n",
-    "email_list = pd.read_csv(\"../mailcom/test/data/mails_lb_sg_copy.csv\")\n",
+    "email_list = pd.read_csv(\"../mailcom/test/data_extended/mails_lb_sg.csv\")\n",
     "print(email_list)\n",
     "\n",
     "t_csv_read = time.time()\n",
@@ -40,15 +74,138 @@
     "ps = mailcom.parse.Pseudonymize()\n",
     "ps.init_spacy(\"fr\")\n",
     "ps.init_transformers()\n",
+    "ld = mailcom.utils.LangDetector()\n",
+    "ld.init_transformers()\n",
     "# time stamp after model loading\n",
     "t_model_loaded = time.time()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
+   "source": [
+    "# loop over mails and detect their languages\n",
+    "lang_out_list = []\n",
+    "lang_ts_list = []\n",
+    "for idx, row in email_list.iterrows():\n",
+    "    ts_email_start = time.time()\n",
+    "    text = row[\"message\"]\n",
+    "    email_dict = {\"content\": text}\n",
+    "    if not text:\n",
+    "        continue\n",
+    "    # Test functionality of LangDetector class\n",
+    "    ts_email_ppr_done = time.time()\n",
+    "    for lang_lib in [\"langid\", \"langdetect\", \"trans\"]:\n",
+    "        det_lang = ld.get_detections(text, lang_lib)\n",
+    "        email_dict[lang_lib] = \"{}-{}\".format(det_lang[0][0], det_lang[0][1])\n",
+    "\n",
+    "    lang_out_list.append(email_dict)\n",
+    "\n",
+    "    # timestamp after this email\n",
+    "    ts_email_end = time.time()\n",
+    "    lang_ts_list.append([ts_email_start, ts_email_ppr_done, ts_email_end])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                               content  langid  \\\n",
+      "0    Von meinem iPhone gesendet Anfang der weiterge...  fr-1.0   \n",
+      "1    Von meinem iPhone gesendet Anfang der weiterge...  fr-1.0   \n",
+      "2    Von meinem iPhone gesendet Anfang der weiterge...  fr-1.0   \n",
+      "3    Von meinem iPhone gesendet Anfang der weiterge...  fr-1.0   \n",
+      "4    Von meinem iPhone gesendet Anfang der weiterge...  fr-1.0   \n",
+      "..                                                 ...     ...   \n",
+      "98   \\nVon: Mélissa des Presses de l'Université Lav...  fr-1.0   \n",
+      "99   Von: Librairie Classiques Garnier &amp;lt;libr...  fr-1.0   \n",
+      "100  La langue s'enrichit #36 - FranceTerme\\nProf. ...  fr-1.0   \n",
+      "101  Activités de juin - Presses de l'Université La...  fr-1.0   \n",
+      "102  Nouveautés de juin\\nProf. Dr. Sybille Große I ...  fr-1.0   \n",
+      "\n",
+      "                langdetect                  trans  \n",
+      "0     fr-0.999997643017964  fr-0.9911757707595825  \n",
+      "1    fr-0.9999985698658455  fr-0.9899152517318726  \n",
+      "2     fr-0.999996534677391  fr-0.9927849769592285  \n",
+      "3    fr-0.9999966462358008  fr-0.9916396737098694  \n",
+      "4    fr-0.7142828117950524  fr-0.9849207997322083  \n",
+      "..                     ...                    ...  \n",
+      "98   fr-0.9999957490263667  fr-0.9911774396896362  \n",
+      "99   fr-0.9999943212158026   fr-0.990962564945221  \n",
+      "100  fr-0.9999963877653447  fr-0.9920682907104492  \n",
+      "101  fr-0.9999945178087889  fr-0.9914606809616089  \n",
+      "102  fr-0.9999946157595117  fr-0.9915869235992432  \n",
+      "\n",
+      "[103 rows x 4 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# write output to pandas df\n",
+    "df = pd.DataFrame(lang_out_list)\n",
+    "print(df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# store the results in a csv file\n",
+    "df.to_csv(out_file, index=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fr-0.9913384914398193\n",
+      "fr-0.9913080334663391\n",
+      "fr-0.9910556077957153\n",
+      "fr-0.9912301301956177\n",
+      "fr-0.9908391833305359\n",
+      "fr-0.9915818572044373\n",
+      "fr-0.9918330907821655\n",
+      "fr-0.9908162355422974\n",
+      "fr-0.9911774396896362\n",
+      "fr-0.990962564945221\n",
+      "fr-0.9920682907104492\n",
+      "fr-0.9914606809616089\n",
+      "fr-0.9915869235992432\n"
+     ]
+    }
+   ],
+   "source": [
+    "for item in df[\"trans\"][90:104]:\n",
+    "    print(item)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "You seem to be using the pipelines sequentially on GPU. In order to maximize efficiency please use a dataset\n"
+     ]
+    }
+   ],
    "source": [
     "# loop over mails and pseudonymize them\n",
     "out_list = []\n",
@@ -85,9 +242,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                                               content  \\\n",
+      "0    Von meinem iPhone gesendet Anfang der weiterge...   \n",
+      "1    Von meinem iPhone gesendet Anfang der weiterge...   \n",
+      "2    Von meinem iPhone gesendet Anfang der weiterge...   \n",
+      "3    Von meinem iPhone gesendet Anfang der weiterge...   \n",
+      "4    Von meinem iPhone gesendet Anfang der weiterge...   \n",
+      "..                                                 ...   \n",
+      "98   \\nVon: Mélissa des Presses de l'Université Lav...   \n",
+      "99   Von: Librairie Classiques Garnier &amp;lt;libr...   \n",
+      "100  La langue s'enrichit #36 - FranceTerme\\nProf. ...   \n",
+      "101  Activités de juin - Presses de l'Université La...   \n",
+      "102  Nouveautés de juin\\nProf. Dr. Sybille Große I ...   \n",
+      "\n",
+      "                                              det_lang  \n",
+      "0    [(fr, 0.9911757707595825), (ru, 0.000684742582...  \n",
+      "1    [(fr, 0.9899152517318726), (ru, 0.000784482806...  \n",
+      "2    [(fr, 0.9927849769592285), (tr, 0.000568731455...  \n",
+      "3    [(fr, 0.9916396737098694), (ru, 0.000675349729...  \n",
+      "4    [(fr, 0.9849207997322083), (en, 0.001657419255...  \n",
+      "..                                                 ...  \n",
+      "98   [(fr, 0.9911774396896362), (ru, 0.000708585081...  \n",
+      "99   [(fr, 0.990962564945221), (ru, 0.0007254832307...  \n",
+      "100  [(fr, 0.9920682907104492), (ru, 0.000636541168...  \n",
+      "101  [(fr, 0.9914606809616089), (ru, 0.000670765293...  \n",
+      "102  [(fr, 0.9915869235992432), (ru, 0.000665231840...  \n",
+      "\n",
+      "[103 rows x 2 columns]\n"
+     ]
+    }
+   ],
    "source": [
     "# write output to pandas df\n",
     "df = pd.DataFrame(out_list)\n",
@@ -96,9 +287,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Total time: 00:10\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAs8AAAE3CAYAAABVW6xeAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAMTgAADE4Bf3eMIwAAUVpJREFUeJzt3XdYFFffP/73AgoqTRQEWWBFSpQioqJRoxJrEkUfsMVKlKLRqMFENNFbzW27vzEYY4oYFaPEEsEYEk3yWLDkjg0jKtiAuAIKokYRbLBwfn/wYx5XEBYElsX367r20p05c+ZzZmaHz549MyMTQggQEREREVGl9LQdABERERGRrmDyTERERESkISbPREREREQaYvJMRERERKQhJs9ERERERBpi8kxEREREpCEmz0REREREGmLyXEXGxsY4dOhQna/Xzc0N3333XZ2vtyLvv/8+rKysYGxsjPPnz2s7nBf29L49dOgQZDIZVCqVdoOqApVKBZlMVqXjUyaTYf/+/dWe/6Kejfno0aMwNjZGUVFRra2ztvTs2ROLFi167vzCwkKMHTsWFhYWMDY2Rm5urtrnWqlUQiaTITU1tY4irr79+/dDJpNJ75ctW4YBAwZoMSIiorqjcfJ8/vx5jB49GjY2NjA2NoZCocDbb7+Nv/76qzbjqxHVSQA2bdoEuVxeZnp+fj769OlTQ5GV9bykLTk5GRMnTqy19VbVsWPH8PXXX+PMmTPIz8+Hh4eHtkN6YbW9b6lyr732GvLz86Gvr6/tUGpcTEwM4uPjoVQqkZ+fDzMzs3r3ua6ujz76CP/7v/+r7TCIiOqERsnzoUOH4OPjg1atWuHYsWPIy8tDYmIi+vfvj507d9Z2jFQPpaWlwdLSEra2ttWuo6CgoAYjIqrf0tLS4OjoCFNT0zpbZ2FhYZ2ti4joZaFR8hwaGorhw4dj9erVUCgUkMlkMDc3x6RJk7B8+XKp3KZNm+Du7g5TU1O4u7urDTMo/Uly48aN8PT0RLNmzdCzZ09kZmbiyy+/hIODA8zNzREaGqr2k61MJkNERAS6dOkCY2Nj+Pj4ICEhQZofGBiIcePGqcXbp08fzJ8/H0DJcAcAGDJkCIyNjfHGG28AAHbu3IlOnTqhefPmaNmyJfz8/HD16lUAJT8dT5kyBTdu3ICxsTGMjY3x/fffS/E83Yu9Z88edOrUCWZmZnBxccHKlStRXFysFv+aNWvQo0cPGBsbw8PDA3/88Ue52zk9PV2Kz9zcHMbGxli2bBkAQKFQYP369S+0La9fv44xY8bA1tYWVlZWePvtt3Hr1i1p/pdffom2bdvCxMQErVq1QmBgYLlxLly4EEFBQdL2Kd3G9+7dQ0hICORyOVq2bIk33ngDly9flpZbtGgRevbsiQULFqB169bw8vIqt/6ioiJ89tlnaNeuHczMzNCpUyccOHBAml/6q8DXX38NBwcHNGvWDIGBgcjLy8PUqVPRokUL2NjYIDIyUlomKysLgwcPRqtWrWBiYgJPT88yX/wq+oUiPj4enTt3hpmZGVq0aIEePXrg7t275ZZ9VnX318WLF/HGG2+gZcuWkMvlCA0NRW5urjQ/JycH/v7+MDc3h6OjI3bs2FFm3SdOnECfPn3QokULODg4YMGCBS80FKWy4z0kJAQKhQLGxsZo06YNFi5cqDa/spif/eWl9JhZvHgxbGxsYGFhgdDQULU2nDx5El26dIGJiQk6d+6MiIgItSEFz9L0WKjoc6tSqTBnzhxYW1vD0tIS8+bNq3C7BQYG4pNPPsGxY8fUzkNPf67Ls3fvXnTt2hXNmzeHs7MzvvjiiwrXo1AosHDhQgwaNAgmJib47LPPAACbN29Ghw4dYGZmBjc3N2zfvr1K2+P06dPo2rUrjI2N0blzZ5w7d05tful+KtWnTx/MnDkTY8aMgZmZGezs7PDNN9+oLRMVFQUnJyeYmJjA398f06dP5y8/RKQbRCWuXLkiAIj//d//rbBcTEyMMDExEfv37xcqlUrs27dPNGvWTPz4449CCCGuXr0qAIj+/fuLmzdviry8PNGjRw/h4uIi5syZIx4/fixSUlKEmZmZ2Lp1q1QvANG2bVuRnJwsHj9+LBYuXChatmwp7t27J4QQYuLEiWLs2LFqsfTu3Vt8/PHHanXs27dPrcyvv/4qEhMThUqlErdu3RKDBw8W3bp1k+ZHRUUJW1vbMu18uq6TJ0+KRo0aiR07dojCwkKRkJAgbGxsxKpVq9TKe3p6ipSUFFFYWChmzpwp7O3tn7sd4+PjBQBRWFioNt3BwUF8++231d6Wjx8/Fq6urmL27NkiPz9f5OXliXHjxol+/foJIUr2c5MmTcT58+eFEELk5eWJw4cPPzfO8rbP4MGDRZ8+fURWVpZ48OCBmDlzppDL5SIvL08IIcTChQuFvr6+WLx4sXj06JF48OBBuXUvXLhQdOjQQVy6dEkUFRWJXbt2iaZNm4rU1FRp3fr6+mL27Nni0aNHIi0tTTRv3ly0a9dO7Nq1S6hUKrFz505hYGAg0tPThRBCZGRkiNjYWJGXlycKCgrE+vXrhYGBgUhKSip33z67H1q3bi02btwoiouLxZMnT8Sff/4p8vPzn7t9nlad/XX//n3RunVrERYWJh48eCBu3LghevXqJYYOHSrV279/fzFw4EBx584dcefOHfHWW28JACI+Pl4IIcSlS5dEs2bNxLZt20RhYaFQKpXC09NTLFmypNw2l6eqx/u3334rsrOzRXFxsTh27JiwsLAQa9eu1TjmZ7f7woULhYGBgfj000/FkydPxOXLl0Xz5s3Fxo0bhRBC3L17V1hYWIjFixeLJ0+eiIsXLwpnZ2dR0alN02Ohos/t0qVLhYODg3Remj9/vjAwMBALFy587noXLlwoevTooTatvM91SkqKEEKIgwcPCjMzM7F//35RVFQkzp8/L+RyuYiOjn7uOhwcHESrVq3En3/+KYqLi8WDBw9EVFSUsLOzE6dOnRJFRUXi6NGjwsTERBw9elSj7ZGbmytatmwp5s+fLx4/fiySk5NF27Zt1bbxs23r3bu3MDU1FQcOHBBFRUUiJiZG6OnpSW07fPiwaNy4sdi7d69QqVRiz549okmTJqJ3797PbRsRUX1RafL8xx9/CADiwoULFZYbMGCAmDVrltq0GTNmiIEDBwoh/u8Pw5EjR6T5n3/+uWjatKlQqVTStMGDB6vVA0B88cUX0vuioiJhbW0tNm/eLISofvL8rL/++ksAEPfv3xdCaJY8h4SEiGHDhqnNj4iIEK6urmrlv/vuO+l9UlKSACCys7PLjaMqyXNVtmVsbKxo3bq1KC4uluZnZmYKACIjI0P8/fffwsjISGzfvl3k5uZWsKVKPLt9bty4IQCIxMREaVpBQYFo0aKF2LZtmxCi5A/sszGUx9TUVPz2229q0/r16yf+/e9/S+s2NDQUBQUF0vxhw4aJAQMGqC1jYmIidu/e/dz1eHp6qh1bFSXPCoVCfPzxxyIzM7PC2MtTnf21detW0bJlS7XjoPQYzcrKkvbduXPnpPnnzp1TS0Tfe+89MXr0aLVYoqOjRdu2bcttc3mqerw/a8aMGcLf318IITSKubzkuU2bNmp1Dh8+XEyZMkUIIcSWLVtEq1atRFFRkTR/zZo1FSbP5SnvWKjoc+vk5KRWXqVSCUtLyxpNnocMGSLmzp2rVn7JkiWib9++z12Hg4NDmWU8PDzUvsAIIURQUJCYPHnyc+t5entER0cLKysrtWP1iy++qDR5fuedd9TqbNmypdi+fbsQQojJkyeLESNGqM0PCAhg8kxEOqHSYRtWVlYAgMzMzArLZWRkoG3btmrTnJyckJ6erjbNxsZG+n+zZs1gaWmpdnFQs2bNkJeXp7ZMmzZtpP/r6enBwcEBGRkZlYVeocOHD6Nv376wsbGBqakpevfuDaDkZ2VNadrm1q1bS/9v1qwZAJRpY3VUZVumpKTg5s2baN68OczNzWFubg43NzcYGhoiPT0dbdq0wfbt2xEVFQV7e3t06dIF27Zt0ziW0v3x9PZo1KgRHBwc1LaHg4NDhT+p37x5E/fv38eIESOkOM3NzfHnn3/i+vXrUrmWLVuiUaNGam19ensAQNOmTaX23717F8HBwWjTpg1MTU1hbm6O5ORkjfd3XFwc/v77b3Tq1AlOTk5YuHBhlYc/VGV/ZWRkwMHBAQYGBtJ8JycnACXDe0o/j09/Np7+P1Cyz3/88Ue17Th16lRkZ2dXKe5SlR3vQggsXboUbm5u0nEWGRkpbWNNYi7P058fQH07Xb9+HXZ2dtDT+79TmUKhqLA+TY+Fij63mZmZarHr6+vD3t6+0rZURUpKClavXq22/1asWIGsrKwKlyvvOJg9e7ZaPdu2bcONGzcAVL49MjMzYWdnp3as1sR+c3BwUJtf2X4jIqovKk2enZ2d4eLigi1btlRYzs7ODmlpaWrT0tLSauQPilKplP5fXFyM9PR06U4YJiYmePDggVr50j8KpZ5N1goKCjB48GAMGjQIV65cwf3793H48GEAJQkAALU/xs9TG23WZL3VYW1tDQcHB9y7d0/t9fjxY3Tv3h0AMHToUPz222+4ffs2PvzwQ4wdOxZXrlzRqH47OzsAUNseKpUK6enpatujsvaZm5vDyMgIv/zyi1qcDx48KDNmsirmzp2LS5cu4fDhw8jNzcW9e/fg5uYm7e/KeHh4YOvWrcjOzkZMTAzWrl2LqKioasdTGTs7O6Snp6sl6KXb1t7eXjr+n/5sPP1/oGSfjxkzRm073r9/H/n5+dWOqaLjffv27fj888+xefNm3L59G/fu3UNoaKi0jTWJuapsbW2RkZGhNq762rVrFS7zoscCUNKWp2MvKip64S/0z7K2tsbcuXPV9l9eXh6Sk5MrXO7Zz5i1tTW+/vprtXry8/Oxd+9eAJVvD7lcjoyMDLXx+DWx357dT5XtNyKi+kKjTC0yMhI7d+5EWFgYrl27BiEE7t+/j82bN+Pjjz8GAAQFBWHjxo04dOgQioqKcPDgQWzYsAEhISEvHOTq1atx8eJFFBQUYOnSpSgoKICfnx8AoHPnzoiPj8elS5dQWFiIzz//XLrwr5S1tbXahWsFBQV49OgRmjdvDhMTE9y4cUO6wPDpZW7fvo07d+48N65JkyZhz549iI2NRVFREc6cOYNPP/30hdpsbW0NAGrx1gR/f38UFhZiwYIF0kVnOTk50gVbly9fxt69e5Gfnw8DAwOYmZkBgMa3DLOxscGbb76J2bNn4+bNm3j06BHCw8PRuHFjvPXWWxrHaWhoiClTpmDOnDm4ePEihBB49OgRjhw5onEiX57c3Fw0bdoULVq0QGFhIdasWVNpElKqoKAAUVFR0sWVZmZm0NfXl3qFSy9ye9GE4mlvvfUWDAwM8NFHH+HRo0fIzs7G+++/jyFDhsDa2hq2trbo27cv5syZg7t37+Lu3bv46KOP1Op49913ERMTg507d6KgoABFRUVITU3Fb7/9Vq2YKjvec3NzYWBgACsrK8hkMsTHxyM6OlpaXpOYq2rw4MEoKCjA8uXLUVBQgCtXrlR6Ud2LHAulJk6ciM8++wyXLl3CkydP8Mknn+Cff/55kaaUMXPmTKxZswYHDhyASqWCSqVCUlISjhw5UqV6Zs2ahX//+984deoUiouL8eTJE5w6dQqnT58GUPn2GDx4MIqKivDJJ5/gyZMnuHTpElavXv1CbRs/fjx++ukn/P777ygqKsJvv/0mJfNERPWdRslznz59cOLECVy/fh0+Pj7SFdm//fYbhg8fDgAYMWIEPvvsM7z77rswNzfHe++9h9WrV8Pf3/+Fg5w6dSrGjx8PCwsLxMXFYe/evTA3NwcAjB07FqNHj0b37t1hZ2eHe/fuoUePHmrLL1++HP/5z39gbm6OwYMHw9jYGOvXr8eSJUukK99HjBihtszrr7+OoUOHwsXFBebm5ti6dWuZuLp27YqYmBgsXboUzZs3x4gRIzBjxgzMnDmz2m11cXHBe++9B19fX+ln2ppgYmKCY8eOIT09HR4eHjA1NUX37t2lP8SlX0xsbW1hamqK2bNnY/PmzWV+pq/Ili1boFAo4O3tDblcjuTkZOzfvx8mJiZVinXlypV4++23paEbCoUCy5cvf6Hbbi1ZsgSPHj1Cq1atoFAocPPmzTLHSUViYmLg5uaGZs2aoXfv3ggMDJTuz3vt2jU4OTm90G37nmVqaop9+/bh7NmzkMvl0nCRp+9gEx0djcaNG0vbfNSoUWp1dOnSBfv27cO3334LW1tbtGjRAsOHD692D19lx3tgYCD69u0LDw8PtGzZEmvXri1zJ5zKYq4qc3Nz7N27Fz/++CMsLCwwZswYTJo0CYaGhs9d5kWPBQAIDw+Hv78/evfuDblcjoKCAnTt2vWF2vKsYcOGYcuWLfjXv/4FKysrWFlZISgoCLdv365SPTNnzsSiRYswZcoUWFhYwNbWFh9++KH0i11l28PMzAx79+7F3r170aJFC4wbNw5Tp059obb17t0bX3/9tfT3IjIyEmPHjoWRkdEL1UtEVBdkoiq/VWqBTCbDvn370K9fP22HQlSusWPHYtiwYWW+gJF2fP755/jmm29q/Ncbql3Dhg1Dq1at1G4xSURUHxlUXoSIKlJ6D3DSjgMHDsDFxQVyuRynT5/GypUra2S4GNWu2NhY9O/fH02aNMGuXbvwyy+/4ODBg9oOi4ioUkyeiUinXbp0CePHj8e9e/dgZWWFcePGITw8XNthUSV+/vlnBAcHo6CgAA4ODti4cSN69eql7bCIiCpV74dtEBERERHVF7VzXzQiIiIiogaIyTMRERERkYY45llDhoaGsLS01HYYRNSA3bp1C0+ePNF2GLWG51Eiqm11cR5l8qwhS0vLSh9RTkT0IkqfwthQ8TxKRLWtLs6jHLZBRERERKQhJs9ERERERBpi8kxEREREpCGOeSaqAUII6UX0PDKZDHp67LMgItJlTJ6JXkBxcTFycnJw7949Js6kkUaNGsHe3h6NGzfWdihERFQNTJ6JXsC1a9egp6cHhUKBRo0aaTscqueEELhz5w7S09Ph5OSk7XCIiKgadCp5TklJwcSJE3H79m2YmZlh06ZNcHNzUyujVCoRGBiIM2fOoE2bNkhMTCxTjxACffv2xV9//YV79+7VTfDU4BQXF+Px48dwdnaGgYFOfZRIi1q0aIF//vkHxcXFHMJBRKSDdOrMHRoaipCQEFy5cgXh4eEIDAwsU8bU1BRLlizB1q1bn1vPqlWr0LZt21qMlF4GpcM0ZDKZliMhXVJ6vHCYDxGRbtKZ5DknJwcJCQkYN24cACAgIAAZGRlITU1VK2dhYYGePXuiWbNm5daTnJyM3bt3Y+7cubUeMxERERE1LDrzW3NGRgZsbGykn8dlMhns7e2rNHawsLAQwcHB2LBhA/T19SssGxERgYiICOl9fn5+9YOnl4pi7p5aqVe54i3N1q9QwNDQEE2aNEFBQQGmTZuGadOmVX+9SiXatm0LDw8PCCFgYGCAlStXwtfXt9p11oYbN25g1KhROHr0qLZDISKiBkxnkueasHjxYvj7+6Ndu3ZQKpUVlg0LC0NYWJj0vlqPe1xkBizKrfpyRC9ox44d8PLywrVr1+Dp6YnXXnsNnp6eAErGagOo0nhbExMT6fqBXbt2YeTIkcjJyVEbsqJSqbQ69rt169ZMnOvQ01/SAGDevHkYNWqUlqOiulRbHQXaoGnnBBGgQ8M27OzskJWVBZVKBaBkvGB6ejrs7e01ruPw4cNYs2YNFAoFevbsifv370OhUODWrVu1FTaRVjk4OMDV1RVjxoxBQEAABg4cCHd3d2RlZeH3339Hz5490alTJ/j4+CA+Pl6jOgcNGoTbt2/jzp076NOnD2bMmIFXX30VAwYMQFFRET788EO4u7vD3d0d7733HgoKCgAAubm5CAoKgru7Ozp06IBJkyYBKPlFaO7cufDx8YGXlxdGjhyJu3fvAgDWr1+P9u3bw8vLCx4eHjhx4gSKi4sxffp0tGvXDh06dECnTp3w+PFjKJVKmJubS3HKZDIsW7YMPj4+aNOmDaKioqR5f/75p1TnpEmT0KFDBxw6dKhmNvpLZMeOHUhMTERiYiITZyJ6aehMz7OVlRW8vb0RHR2NwMBAxMbGQi6XV+l2T0/3SimVSnh5eVXaA02ky86fP49Lly5hyJAhiI+Px5kzZ9CqVSv8/fffWLRoEX7//XeYmpoiNTUVr732GpRKJQwNDSusc9u2bbC3t0fLli0BAFeuXMGRI0fQqFEjfPPNNzh16hROnz4NfX19+Pn5YdWqVQgPD8esWbPQpEkTnDt3Dnp6etKX1k8//RTNmjXDyZMnAQD//ve/MX/+fHz11VeYPXs2Ll26BBsbGxQWFuLJkyc4e/YsDhw4gOTkZOjp6SE3N/e590w2NDTEyZMncenSJXTp0gXjx49HcXExRo0ahc2bN8PX1xfx8fFqiTUREVFFdCZ5BoDIyEgEBgZi2bJlMDU1lf7gBQUFwc/PD35+fnj48CFcXFzw5MkT5ObmQi6XY/z48Vi+fLmWoyeqO6NGjUKTJk3QtGlTbNy4EUlJSWjSpAlatWoFAPjtt9+QmpqKXr16Scvo6ekhPT0dzs7OZerLy8uDl5cXAMDW1hZxcXHSvHHjxkn3uN6/fz8CAwOlBDw4OBhfffUVwsPD8csvv+DEiRPScBFLS0sAwO7du5Gbm4vY2FgAQEFBARQKBQCgb9++GD9+PIYMGYI33ngDLi4ucHR0hEqlwqRJk+Dr64u33nrruUNQxo4dCwB45ZVXYGBggOzsbPzzzz8wMDCQxmz7+vry7jvVNGHCBAgh4OPjgxUrVkj7lIioIdOp5NnV1RXHjh0rM339+vXS/5s2bYrMzMxK61IoFLzHMzVYpWOeSyUlJcHY2Fh6L4RA//79y72l44wZM3DkyBEAwJYtW2BiYqI25vlZT9f7LE1u4yeEwJo1azBgwIAy82JjY3H69GkcOnQIb775JpYsWYLRo0cjKSkJhw8fRnx8PObNm4cjR46UO97ayMhI+r++vr407Ks6cZK6I0eOwN7eHoWFhZg/fz4mTpyIvXv3qpXhhddE1BDpzJhnIqo5AwcOxP79+3Hu3DlpWumwiS+++EIax+rh4VGlevv164fNmzejoKAAKpUK69evl5JiPz8/rFy5UrpgsXTYxrBhw7Bq1So8fPgQAPDw4UMkJydDpVIhLS0NnTt3xgcffIDhw4fj5MmTuHXrFh48eIABAwZg2bJlUCgUuHDhgsYxurq6orCwEIcPHwZQci3Es7e8pMqVXm/SqFEjzJo1q9yLNcPCwpCZmSm9KvqiRUSkK3Sq55lIF+jCVdtOTk7YunUrQkND8fDhQxQUFKBjx44VPlxIEyEhIUhLS4O3tzcAoE+fPpg1axaAkocTvf/++/Dw8ECjRo3QpUsXfPvttwgPD8eTJ0/QtWtXqQc4PDwcTk5OmDRpkjTMwtLSElFRUcjIyEBwcDAKCwtRVFSEHj164I033sD169c1itHQ0BDbt2/HtGnTUFxcjE6dOsHV1VXtYkOq2IMHD1BYWChts23btqFjx47aDYqIqI7IBB9zpRG5XK7RcBA1vFVdg1ZUVIQrV67AxcWl0vuGU/2Sl5cHExMTAMCpU6fg5+eHtLQ0NG3atNbXXdFxU63zjBb8/fffCAgIQFFREYQQcHR0xOrVq6Wx6s+jK+0jzfBWdVQf1cV5hj3PRPTSiY2NxapVq6SHvmzZsqVOEueGwtHREWfOnNF2GEREWsHkmYheOoGBgQgMDNR2GEREpIN4wSARERERkYaYPBMRERERaYjJMxERERGRhpg8ExERERFpiBcMEtW0RWa1VK9mtz1UKBQwNDREkyZNUFBQgGnTpmHatGm1E9P/b/jw4Rg8eLDWL8JLSEjAp59+ih07dlRr+cTERFy6dAmjR4+Wpnl5eeHo0aPSre2IiOjlxp5nogZox44dSExMxK+//oqPPvpI7UmCDVnnzp2rnTgDJcnz9u3by0xj4kxERKWYPBM1YA4ODnB1dcXZs2fh6ekJLy8vuLu746effgIAZGdnY+TIkfDx8YGHhwfmz58vLatQKJCYmCi979y5Mw4dOgQAuHTpErp37w43NzcMGzYM9+/fl8rl5OTA398fHh4ecHd3R2RkpFqd//rXv/Dqq6+iTZs2WLJkCYCSHuNXXnkFTz+zqXv37vj111+hVCphbm6OBQsWwNvbG87Ozvjvf/+L999/X2pPUlISAODQoUPw8vICAKxfvx5eXl7SS19fH4cPH0Z2djZ8fX3RqVMnuLm5Yfr06SguLkZOTg7+9a9/IT4+Hl5eXpgyZQoAQCaT4d69e1Kc3bt3h6enJ3x8fPDf//4XAKQYFy5ciE6dOsHJyQl79+6tgT1IRET1DZNnogbs/PnzuHTpEqZMmYLIyEgkJibi3Llz6N27NwBg4sSJmDZtGk6ePIkzZ84gISEBO3furLTe8ePHY/LkyUhOTsa///1vHD58WJr33nvvwdXVFefPn8fBgwexZMkSHD9+XJp/7949HDt2DKdOncKnn36K69evo3PnzmjRogX27dsHADhz5gxu3bqFQYMGAQByc3PRqVMn/PXXX5g7dy4GDhwIPz8/JCYmYuLEiVi8eHGZGIOCgpCYmIjExESMGDEC/fr1Q48ePWBubo6ff/4Zp0+fxrlz56BUKvHDDz/AysoKn3zyCXx9fZGYmIi1a9eq1VdQUAB/f38sXLgQ586dQ0REBAICApCfny/F6OnpidOnT+PLL7/E+++/X8W9RUREuoBjnokaoFGjRqFJkyZo2rQpNm7ciD///BMzZ87E8OHDMWDAAHh5eeHBgwc4cOAAbt68KS2Xn5+Py5cvV1j3/fv3kZiYKI1v9vDwQM+ePaX5+/fvx+nTpwEAVlZW8Pf3x/79+9GtWzcAwJgxYwAALVu2hKOjI65evQpbW1vMnDkTX375JQYMGICvvvoK7777LmQyGQDAyMgIw4YNA1DSA25sbAxfX18AgI+PD77//vvnxrtlyxbExsbi8OHDMDAwQEFBAcLDw/HHH39ACIGcnBy4u7urjXMuz+XLl6Gnp4eBAwcCAHr27IlWrVohMTERcrkcRkZG8Pf3BwC8+uqrSEtLq7A+IiLSTUyeiRqgHTt2SMMXgJIL+pKTkxEfH4+JEydi7NixePfddwEAx48fh5GRUZk6DAwMUFRUJL1//Pjxc9dXmuRqMu/pdenr60OlUgEA/P39MWfOHJw5cwZxcXFYuXKlVM7Q0FBtmefV8ayDBw/ik08+wZEjR6RxyxEREcjJycGJEydgZGSEsLCwCttWkafbZmhoKL3X19dX23ZERNRwcNgG0Uvg0qVL0vjeqVOn4vjx41Lv7YoVK6RyN27cQGZmJgDAyckJJ06cAACcPHlS6pE2NTVFx44dsXnzZgBAcnIy/vjjD6mOfv364dtvvwUA3Lp1C7t27UL//v0rjdHAwABTpkyBn58f/ud//gfm5uYv1Obz589j0qRJ2L17N2xsbKTpd+/ehbW1NYyMjJCdna02TMXU1BS5ueXf1cTV1RXFxcXS0JI///wT2dnZal9SiIio4WPyTPQS+Oijj+Dm5oaOHTtiy5YtWLRoEQDg+++/R2pqKtzd3eHh4QF/f3/cuXMHALBkyRJ89dVX6NChAzZu3Ag3Nzepvs2bN2PdunVwd3fH/Pnz0atXL2neF198gYsXL8LDwwO+vr74+OOP0bVrV43inDx5Mq5fv47p06e/cJsjIiLw4MEDjB07VrpoMCEhATNnzsSJEyfg5uaG8ePHo1+/ftIyffv2xZMnT+Dp6SldMFiqcePG2LVrFxYuXAhPT0/MmjULMTExMDY2fuFYiYhId8jE05e303PJ5XKpR05ji8w0vjcv6Z6ioiJcuXIFLi4u0NfX13Y4DUJMTAy++eYbHDhwQNuh1JqKjptqnWd0SENv38tGMXePtkOoMcoVb2k7BKohdXGe4ZhnIqoXBg0ahCtXruDHH3/UdihERETPxeSZiOqF3377TdshEBERVYpjnomIiIiINMTkmaiaSm9LxssGqCpKj5eKbu9HRET1F4dtEFWTnp4ejIyMcP36dbRq1QqNGjXSdkhUzwkhcOfOHTRq1Ah6euy7ICLSRUyeiV6Ag4MDcnJyoFQq2QNNGmnUqBHs7e21HQYREVWTTiXPKSkpmDhxIm7fvg0zMzNs2rRJ7d6zAKBUKhEYGIgzZ86gTZs2SExMlOYdPHgQc+fORX5+PmQyGd566y2sWLGCPUBUbXp6erC2tkarVq0ghGACTRWSyWQ83xAR6TidSp5DQ0MREhKCwMBAxMTEIDAwEKdOnVIrY2pqiiVLliA3Nxcff/yx2rzmzZtj+/btcHR0xOPHj9GvXz9s3rwZgYGBddgKaohkMhnHsBIREb0EdKYLJCcnBwkJCRg3bhwAICAgABkZGUhNTVUrZ2FhgZ49e6JZs2Zl6ujYsSMcHR0BAEZGRvDy8oJSqaz12ImIiIioYdCZ5DkjIwM2NjYwMCjpLJfJZLC3t0d6enq16svOzkZMTAwGDx5ck2ESERERUQOmM8lzTbp//z6GDBmCOXPmoHPnzuWWiYiIgFwul175+fl1HCURERER1Tc6kzzb2dkhKysLKpUKQMktn9LT06t81XpeXh4GDRqEoUOHIiws7LnlwsLCkJmZKb2MjY1fKH4iIiIi0n06kzxbWVnB29sb0dHRAIDY2FjI5XI4OTlpXEd+fj4GDRqEQYMGYf78+bUVKhERERE1UDqTPANAZGQkIiMj4eLighUrViAqKgoAEBQUhLi4OADAw4cPIZfLMWLECFy4cAFyuRzz5s0DAKxevRonT57Erl274OXlBS8vLyxdulRr7SEiIiIi3SITvDGtRuRyOTIzM6u20CIzYFFu7QRERA1Otc4zOqSht+9lo5i7R9sh1Bjlire0HQLVkLo4z+hUzzMRERERkTYxeSYiIiIi0hCTZyIiIiIiDTF5JiIiIiLSEJNnIiIiIiINMXkmIiIiItIQk2ciIiIiIg0xeSYiIiIi0hCTZyIiqraoqCjIZDLs3r1b26EQEdUJJs9ERFQtSqUS3377Lbp166btUIiI6gyTZyIiqrLi4mIEBQVhzZo1MDQ01HY4RER1hskzERFVWUREBHr06IFOnTppOxQiojploO0AiIhItyQlJSE2NhZHjhypsFxERAQiIiKk9/n5+bUdGhFRrWPPMxERVcnRo0ehVCrh7OwMhUKB48ePIyQkBN98841aubCwMGRmZkovY2NjLUVMRFRzmDwTEVGVTJ06FVlZWVAqlVAqlejWrRvWrVuHqVOnajs0IqJax+SZiIiIiEhDHPNMREQv5NChQ9oOgYiozrDnmYiIiIhIQ0yeiYiIiIg0xOSZiIiIiEhDTJ6JiIiIiDTE5JmIiIiISENMnomIiIiINMTkmYiIiIhIQ0yeiYiIiIg0pFPJc0pKCrp37w4XFxd06dIFycnJZcoolUr06dMHZmZm8PLyKjN/w4YNcHZ2Rtu2bREcHIzCwsI6iJyIiIiIGgKdSp5DQ0MREhKCK1euIDw8HIGBgWXKmJqaYsmSJdi6dWuZeVevXsWCBQtw9OhRpKam4ubNm1i3bl0dRE5EREREDYHOJM85OTlISEjAuHHjAAABAQHIyMhAamqqWjkLCwv07NkTzZo1K1NHTEwM/Pz8YG1tDZlMhilTpmDbtm11Ej8RERER6T6dSZ4zMjJgY2MDAwMDAIBMJoO9vT3S09M1riM9PR0ODg7Se4VCUaXliYiIiOjlpjPJc12LiIiAXC6XXvn5+doOiYiIiIi0TGeSZzs7O2RlZUGlUgEAhBBIT0+Hvb29xnXY29vj2rVr0nulUvnc5cPCwpCZmSm9jI2NX6wBRERERKTzdCZ5trKygre3N6KjowEAsbGxkMvlcHJy0riOgIAAxMXFITs7G0IIrF27FqNHj66tkImIiIiogdGZ5BkAIiMjERkZCRcXF6xYsQJRUVEAgKCgIMTFxQEAHj58CLlcjhEjRuDChQuQy+WYN28eAMDR0RGLFy9Gjx494OTkBEtLS4SGhmqtPURERESkWwy0HUBVuLq64tixY2Wmr1+/Xvp/06ZNkZmZ+dw6goODERwcXCvxEREREVHDplM9z0RERERE2sTkmYiIiIhIQ0yeiYiIiIg0xOSZiIiIiEhDTJ6JiIiIiDTE5JmIiIiISENMnomIiIiINMTkmYiIiIhIQ0yeiYiIiIg0xOSZiIiIiEhDTJ6JiIiIiDTE5JmIiIiISENMnomIiIiINMTkmYiIiIhIQ0yeiYiIiIg0xOSZiIiIiEhDTJ6JiIiIiDTE5JmIiIiISENMnomIiIiINMTkmYiIiIhIQ0yeiYiIiIg0ZKDtAIiISPcMGDAA2dnZ0NPTg4mJCb744gt07NhR22EREdU6Js9ERFRlP/zwA8zNzQEAP/74IwIDA3H27FntBkVEVAc4bIOIiKqsNHEGgNzcXMhkMu0FQ0RUh9jzTERE1TJhwgTEx8cDAPbu3VtmfkREBCIiIqT3+fn5dRYbEVFt0ame55SUFHTv3h0uLi7o0qULkpOTyy23YcMGODs7o23btggODkZhYSEAoLi4GGFhYWjfvj08PT3h6+uL1NTUumwCEVGDsXnzZmRkZGDJkiUIDw8vMz8sLAyZmZnSy9jYWAtREhHVLJ1KnkNDQxESEoIrV64gPDwcgYGBZcpcvXoVCxYswNGjR5GamoqbN29i3bp1AIC4uDj897//xdmzZ3Hu3Dn07dsXH330UR23goioYZk4cSLi4+Nx584dbYdCRFTrdCZ5zsnJQUJCAsaNGwcACAgIQEZGRpme45iYGPj5+cHa2hoymQxTpkzBtm3bAAAymQxPnjzB48ePIYTA/fv3IZfL67wtRES67N69e7hx44b0fvfu3WjRogUsLCy0GBURUd3QmTHPGRkZsLGxgYFBScgymQz29vZIT0+Hk5OTVC49PR0ODg7Se4VCgfT0dADAkCFDEB8fD2tra5iYmMDW1haHDx8ud30cq0dEVL7c3FyMGDECjx49gp6eHiwtLfHLL7/wokEieinoTPJcExISEpCUlITr16/D1NQUc+fOxZQpUxAdHV2mbFhYGMLCwqT37KEmIirh4OCAkydPajsMIiKtqNPk+elk9HlMTU2xaNGiMtPt7OyQlZUFlUoFAwMDCCGQnp4Oe3t7tXL29vZIS0uT3iuVSqnM5s2b8frrr0u3WJo4cSIGDBhQ/QYRERER0UulTsc8b9u2DWZmZhW+tm7dWu6yVlZW8Pb2lnqJY2NjIZfL1YZsACVjoePi4pCdnQ0hBNauXYvRo0cDABwdHXHw4EEUFBQAAH755Re4u7vXYouJiIiIqCGp057nvn37YuHChRWWSUlJee68yMhIBAYGYtmyZTA1NUVUVBQAICgoCH5+fvDz84OjoyMWL16MHj16AAD69OmD0NBQAMC0adNw8eJFdOjQAY0aNYK1tTXWrl1bQ60jIiIiooZOJoQQ2g5CF8jlcmRmZlZtoUVmwKLc2gmIiBqcap1ndEhDb9/LRjF3j7ZDqDHKFW9pOwSqIXVxntHKrepOnTqFhw8fAgB++OEHfPDBB2q3PSIiIiIiqo+0kjwHBQXB0NAQKSkp+Pjjj9GoUSO888472giFiIiIiEhjWkme9fX1oa+vj19//RVTp07F8uXLkZOTo41QiIiIiIg0ppXk+cmTJ7h58yZ+/vln9OnTBwBQVFSkjVCIiIiIiDSmleT5/fffh6urK8zMzODt7Y20tDQ0b95cG6EQEREREWlMa2Oe7927h5iYGAAlj9Det2+fNkIhIiIiItJYnSbP586dK3e6vr4+GjduXGEZIiIiIiJtq9PkOTAwsEbKEBERERFpQ50+YfDs2bOwsLB47nwhBJo1a1aHERERERERaa5Ok+e///670jL6+vp1EAkRERERUdXVafLs4OBQl6sjIiIiIqpRWrnbBhERERGRLmLyTERERESkIa0kz7dv39ZoGhERERFRfaKV5HnAgAEaTSMiIiIiqk/q9ILBgoICPH78GEVFRcjLy4MQAgCQm5uLBw8e1GUoRERERERVVqc9z8uXL4e5uTmSkpJgZmYGc3NzmJubw8PDA+PGjavLUIiIiIiIqqxOk+eFCxeiuLgYISEhKC4ull737t3DggUL6jIUIiIiIqIq08qY52+++UYbqyUiIiIieiG8VR0RERERkYaYPBMRERERaYjJMxERERGRhpg8ExERERFpiMkzEREREZGGdCp5TklJQffu3eHi4oIuXbogOTm53HIbNmyAs7Mz2rZti+DgYBQWFkrzzp8/jz59+qBdu3Zo164ddu3aVVfhExEREZGO06nkOTQ0FCEhIbhy5QrCw8MRGBhYpszVq1exYMECHD16FKmpqbh58ybWrVsHAHj48CGGDh2KJUuW4OLFi0hKSsJrr71Wx60gIiIiIl2lM8lzTk4OEhISpCcRBgQEICMjA6mpqWrlYmJi4OfnB2tra8hkMkyZMgXbtm0DAGzduhXdunVDz549AQD6+vqwtLSs24YQERERkc7SmeQ5IyMDNjY2MDAwAADIZDLY29sjPT1drVx6ejocHByk9wqFQipz4cIFGBoaYvDgwfDy8sKECRNw69atumsEEREREek0nUmea4JKpcL+/fsRGRmJM2fOwNbWFlOnTi23bEREBORyufTKz8+v42iJiIiIqL7RmeTZzs4OWVlZUKlUAAAhBNLT02Fvb69Wzt7eHteuXZPeK5VKqYy9vT18fX1ha2sLmUyGcePG4fjx4+WuLywsDJmZmdLL2Ni4llpGRERERLpCZ5JnKysreHt7Izo6GgAQGxsLuVwOJycntXIBAQGIi4tDdnY2hBBYu3YtRo8eDQAYOXIkTp06hfv37wMA9u7diw4dOtRtQ4iIiIhIZxloO4CqiIyMRGBgIJYtWwZTU1NERUUBAIKCguDn5wc/Pz84Ojpi8eLF6NGjBwCgT58+CA0NBVDS8/zRRx+he/fu0NPTg62trXQnDiIiIiKiysiEEELbQegCuVyOzMzMqi20yAxYlFs7ARFRg1Ot84wOaejte9ko5u7Rdgg1RrniLW2HQDWkLs4zOjNsg4iI6ofHjx9j2LBhcHFxQYcOHdC/f/8ytw0lImqomDwTEVGVhYSE4PLlyzh79iyGDh2KoKAgbYdERFQnmDwTEVGVGBkZ4c0334RMJgMAdOvWDUqlUrtBERHVESbPRET0QlavXo2hQ4eWmc775RNRQ6RTd9sgIqL6ZdmyZUhNTcWBAwfKzAsLC0NYWJj0Xi6X12VoRES1gskzERFVy8qVK7Fr1y7s378fTZs21XY4RER1gskzERFVWUREBLZt24b9+/fD3Nxc2+EQEdUZJs9ERFQlmZmZmD17NhwdHeHr6wsAMDQ0xIkTJ7QcGRFR7WPyTEREVSKXy8HnaxHRy4p32yAiIiIi0hCTZyIiIiIiDTF5JiIiIiLSEJNnIiIiIiINMXkmIiIiItIQk2ciIiIiIg0xeSYiIiIi0hCTZyIiIiIiDTF5JiIiIiLSEJNnIiIiIiINMXkmIiIiItIQk2ciIiIiIg0xeSYiIiIi0hCTZyIiIiIiDTF5JiIiIiLSEJNnIiIiIiIN6VTynJKSgu7du8PFxQVdunRBcnJyueU2bNgAZ2dntG3bFsHBwSgsLFSbL4TA66+/DnNz8zqImoiIiIgaCp1KnkNDQxESEoIrV64gPDwcgYGBZcpcvXoVCxYswNGjR5GamoqbN29i3bp1amVWrVqFtm3b1lHURERERNRQ6EzynJOTg4SEBIwbNw4AEBAQgIyMDKSmpqqVi4mJgZ+fH6ytrSGTyTBlyhRs27ZNmp+cnIzdu3dj7ty5dRo/EREREek+nUmeMzIyYGNjAwMDAwCATCaDvb090tPT1cqlp6fDwcFBeq9QKKQyhYWFCA4ORmRkJPT19esueCIiIiJqEHQmea4Jixcvhr+/P9q1a1dp2YiICMjlcumVn59fBxESERERUX2mM8mznZ0dsrKyoFKpAJRc9Jeeng57e3u1cvb29rh27Zr0XqlUSmUOHz6MNWvWQKFQoGfPnrh//z4UCgVu3bpVZn1hYWHIzMyUXsbGxrXYOiIiIiLSBTqTPFtZWcHb2xvR0dEAgNjYWMjlcjg5OamVCwgIQFxcHLKzsyGEwNq1azF69GgAwNGjR3Ht2jUolUr88ccfMDU1hVKphKWlZZ23h4iIiIh0j84kzwAQGRmJyMhIuLi4YMWKFYiKigIABAUFIS4uDgDg6OiIxYsXo0ePHnBycoKlpSVCQ0O1GTZRWYvMtB0BERERVYOBtgOoCldXVxw7dqzM9PXr16u9Dw4ORnBwcIV1KRQK3Lt3rybDIyIiIqIGTqd6nomIiIiItInJMxERERGRhpg8ExERERFpiMkzEREREZGGmDwTEREREWmIyTMRERERkYaYPBMRERERaYjJMxERERGRhpg8ExERERFpiMkzEREREZGGdOrx3ERE9HJRzN2j7RBqjHLFW9oOgYhqAHueiYiIiIg0xOSZiIiqbMaMGVAoFJDJZEhMTNR2OEREdYbJMxERVdnw4cPxxx9/wMHBQduhEBHVKY55JiLdsMjs//83V7txEACgV69e2g6BiEgr2PNMRERERKQhJs9E1DBIPdNm//d/0qqIiAjI5XLplZ+fr+2QiIheGJNnIiKqFWFhYcjMzJRexsbG2g6JiOiFMXkm0lUNsYdV0/Y0tHYTEZHOYPJMRPXP018M6iJRZjJeZaGhoZDL5cjMzMTAgQPh5OSk7ZCIiOoE77ZBRNqxyIx3ztBhkZGR2g6BiEgr2PNMRFSqIQ6FISKiGsXkmYjKYgLJbUBEROVi8lzf1fXYz+fFQNpVH3pEy1t/TcRUH9r2InQ5diIiqjKdSp5TUlLQvXt3uLi4oEuXLkhOTi633IYNG+Ds7Iy2bdsiODgYhYWFAICDBw/Cx8cH7du3h5ubG+bMmYPi4uLaD7y+Jwf1PT7SXF3sy/LW8bIcQy9DG4mIqEI6lTyHhoYiJCQEV65cQXh4OAIDA8uUuXr1KhYsWICjR48iNTUVN2/exLp16wAAzZs3x/bt23HhwgWcPn0af/75JzZv3lzHragDfFhEzXuRW6hxf2i/3dr6UkFERA2OziTPOTk5SEhIwLhx4wAAAQEByMjIQGpqqlq5mJgY+Pn5wdraGjKZDFOmTMG2bdsAAB07doSjoyMAwMjICF5eXlAqlXXaDo1/+q7oj3B5Qzn4h1tdVbdFdXpTa2t7V2e9tXW8NMTjqiaOjZpeBxER6QydSZ4zMjJgY2MDA4OSu+vJZDLY29sjPT1drVx6ejocHByk9wqFokwZAMjOzkZMTAwGDx5cu4E/T10nJQ3tj7m2xoJrmmTXVML1Im2rj/u8po97bSX3DfFLBRERaURnkueadP/+fQwZMgRz5sxB586dyy0TEREBuVwuvfLz82s/sPrwB1nb669MfY+vqurDPiciIiKN6UzybGdnh6ysLKhUKgCAEALp6emwt7dXK2dvb49r165J75VKpVqZvLw8DBo0CEOHDkVYWNhz1xcWFobMzEzpZWxsXMMtokrVdFLJJJWIiIhekM4kz1ZWVvD29kZ0dDQAIDY2FnK5vMwjYQMCAhAXF4fs7GwIIbB27VqMHj0aAJCfn49BgwZh0KBBmD9/fp23gYiIiIh0m84kz0DJ42AjIyPh4uKCFStWICoqCgAQFBSEuLg4AICjoyMWL16MHj16wMnJCZaWlggNDQUArF69GidPnsSuXbvg5eUFLy8vLF26VGvtISIiIiLdYqDtAKrC1dUVx44dKzN9/fr1au+Dg4MRHBxcptzHH3+Mjz/+uNbiIx20yAxYlKvtKIiIiEhH6FTPMxERERGRNjF5phfDh0+QruJxRURE1cDkmRoOJkNERERUy5g8k/Yw2aXaxuOLiIhqGJNnqjlMVIiIiKiBY/JMRDWLX6KIiKgBY/JM1VNbCRIvQCQiIqJ6jMkz1bynk1NNk9T6lMzWp1iIiIioXmHyTES1gz38RETUADF5Js3VVDLEhIqIiIh0FJNnKl9D6TVsKO0gIiKieoHJ88uGySQ9D48NIiKiSjF5JnrZMWEmIiLSGJNnIiIiIiINMXl+mdVljyOHBBAREVEDwOSZiIiIiEhDTJ6JiIiIiDTE5JmIiIiISENMnomIiIiINMTkmYiIiIhIQ0yeiYiIiIg0xOSZiIiIiEhDTJ6JiIiIiDTE5JmIiIiISENMnomIiIiINKRTyXNKSgq6d+8OFxcXdOnSBcnJyeWW27BhA5ydndG2bVsEBwejsLBQo3lERKQZTc/HREQNjU4lz6GhoQgJCcGVK1cQHh6OwMDAMmWuXr2KBQsW4OjRo0hNTcXNmzexbt26SucREZHmNDkfExE1RDqTPOfk5CAhIQHjxo0DAAQEBCAjIwOpqalq5WJiYuDn5wdra2vIZDJMmTIF27Ztq3QeERFpRtPzMRFRQ2Sg7QA0lZGRARsbGxgYlIQsk8lgb2+P9PR0ODk5SeXS09Ph4OAgvVcoFEhPT690HhERaUbT8zER1T3F3D3aDqHGKFe8pe0QyiUTQghtB6GJ06dPY8yYMbh8+bI0zcfHBytWrMDrr78uTXvvvffQunVrzJs3DwBw4cIFDBo0COnp6RXOe1ZERAQiIiKk99nZ2bC2tq5y3Pn5+TA2Nq7ycvUN21F/NIQ2AGxHeW7duoUnT57USF21SdPzcU2dR+tCQzkeGxrul/qrvu6bujiP6kzPs52dHbKysqBSqWBgYAAhBNLT02Fvb69Wzt7eHmlpadJ7pVIplalo3rPCwsIQFhb2wnHL5XJkZma+cD3axnbUHw2hDQDbocs0PR/X1Hm0LryM+1EXcL/UXy/zvtGZMc9WVlbw9vZGdHQ0ACA2NhZyubzMT4QBAQGIi4tDdnY2hBBYu3YtRo8eXek8IiLSjKbnYyKihkhnkmcAiIyMRGRkJFxcXLBixQpERUUBAIKCghAXFwcAcHR0xOLFi9GjRw84OTnB0tISoaGhlc4jIiLNPe98TETU0OnMsA0AcHV1xbFjx8pMX79+vdr74OBgBAcHl1tHRfNqg678ZFkZtqP+aAhtANgOXfe887Gueln3Y33H/VJ/vcz7RmcuGCQiIiIi0jadGrZBRERERKRNTJ6JiIiIiDTE5LmWpKSkoHv37nBxcUGXLl2QnJys7ZAq9fjxYwwbNgwuLi7o0KED+vfvLz0xLCcnB4MGDYKzszPc3d1x5MgRLUermaioKMhkMuzevRuA7rXjyZMnmD59OpydneHh4SE90U3Xjq+9e/fC29sbXl5ecHd3x3fffQeg/u+PGTNmQKFQQCaTITExUZpe0fbXtX2jTSqVCosXL8Yrr7wCd3d3eHl5ISQkBPfu3QMAfPLJJ3B3d0eHDh3wyiuv4MMPPwQAtG/fHr/88otaXQUFBbC0tMRff/1VZj0KhQKurq7w8vKCq6srVqxYUeNtadmyJZRKJQDgzTffVLsHdn2nUChgZWWFwsJCaVp8fDxkMhlmzZpV5fo++OADLFq0qNJygYGB+Pzzz58b09OfuZr0yy+/oE+fPgCAhIQEjBo1qlbWUyovLw/GxsaYPHlyra6ntmzatAlmZmbw8vKSXtOmTavRdQQFBSE+Ph7A84+L0nW3b98e+vr60vtRo0bhX//6F77//vsajalCgmqFr6+viIqKEkIIsXPnTtG5c2ftBqSBR48eiT179oji4mIhhBBr1qwRvXv3FkII8c4774iFCxcKIYQ4efKksLW1FQUFBVqKVDNXr14Vr776qujWrZv48ccfhRC6145Zs2aJ6dOnS/skKytLCKFbx1dxcbFo3ry5OHv2rBCiZL8YGhqK+/fv1/v9cfjwYZGRkSEcHBzEmTNnpOkVbX9d2jfaNmHCBDF48GDxzz//CCFKjpUffvhBpKWliZ07d4pu3bqJhw8fCiGEKCwsFImJiUIIIVauXCn8/f3V6tq5c6fw8vIqdz1P77/MzExhamoqTpw4UaNtadGihbh69WqN1llXHBwcRKdOnURMTIw0bezYsaJz585i5syZVa5v9uzZ0ue6IhMnThSrVq16bkxPf+Zq0s8//yz9basL3377rejVq5cwNzcXeXl5NVZvUVGRKCoqqrH6nicqKkoMHTq01tdTqqLjQoiSvyFmZmZ1Fk952PNcC3JycpCQkCD1EgYEBCAjI0Pqxa2vjIyM8Oabb0ImkwEAunXrJvWk/PDDD5gyZQoAoEuXLmjdujUOHz6srVArVVxcjKCgIKxZswaGhobSdF1qx4MHD7BhwwYsXbpU2ifW1tY6eXzJZDKpN/H+/fto0aIFDA0N6/3+6NWrF+Ryudq0ira/Lu4bbUlNTcXOnTsRFRWF5s2bAyg5TkaMGAFHR0dkZmbCwsICRkZGAAADAwN06NABADB+/Hj8/vvvuH37tlTfxo0bNerZs7W1xSuvvIJr164BKHnq4ciRI+Hj4wMPDw/Mnz9fKvvBBx+gS5cu8PLyQq9evdR6k+Pi4tCuXTt4enpizpw5aut4ute0T58++OCDD/Daa6+hbdu20vEOAFlZWRgwYADat2+PAQMGYPTo0Rr12NaGd955Bxs3bgQA5Obm4vjx4xg0aJA0v6ioCB9++CHc3d3h7u6O9957DwUFBQBK2jFw4EC0b98e/fr1U3twRmFhIebOnQsfHx94eXlh5MiRuHv3brXj/P333+Ht7Q1PT0/07t0bFy5cAFCyH319fdGpUye4ublh+vTpKC4ulmJ499134ezsDB8fH6mHEwAOHToELy8vACUPTjM3N8fChQvRqVMnODk5Ye/evVLZn376Ce3atUOHDh0QHh6u9mtDRTZs2IDw8HD06tULO3bsAAAsXboU06dPl8rk5+fDwsICt27dAgCsXLkSPj4+8Pb2xqBBg6TjddGiRQgICMDAgQPh7u6OrKysCo/TimJOSUnBW2+9hS5dusDT0xNffvllFfdGSTwjR47EkCFD4OLigsGDByMpKQkDBw6Ei4sL3n77bWk/bN26FV27dkXHjh3RoUMH/Pzzz1I9ffr0kX4hro6ne6urElNeXh6Cg4Ph4+MDT09PhISESMd1RZg814KMjAzY2NjAwKDkToAymQz29vblPga8Plu9ejWGDh2KO3fuoLCwUO2xugqFol63JyIiAj169ECnTp2kabrWjrS0NFhYWGDZsmXo3LkzXnvtNRw4cEDnji+ZTIYdO3bA398fDg4O6NmzJ7777jvk5eXp1P4oVdH217V9o01//fUXnJ2d0bJly3Lnjx49GlevXoWjoyMmTJiAjRs34tGjRwBKHtIycOBA6SEt169fx5EjRzB27NhK13vp0iXcuXNH+tl+4sSJmDZtGk6ePIkzZ84gISEBO3fuBACEh4fj1KlTSExMxLvvvouZM2cCKPkC9c477yA2Nhbnzp2Dk5MT7ty589x1pqWlIT4+HklJSfj999+lW/zNmDEDr776Ki5cuIDNmzfj0KFDGm272tCjRw8olUrcuHED27Ztw4gRI6Cvry/NX7duHU6dOoXTp08jMTERaWlpWLVqFYCSdvj4+ODChQv47rvvcODAAWm5Tz/9FM2aNcPJkyeRmJhY5gtKVeTk5GDMmDH47rvvcO7cOYSEhGD48OEQQsDc3Bw///wzTp8+jXPnzkGpVOKHH36QYr98+TKSk5Pxxx9/lDu0p1Rubi48PT1x+vRpfPnll3j//feldU+aNAk//vgjzp49i1deeaXCfV7qwoULyMjIwMCBAzF58mRs2LABADBhwgT88MMP0mOkd+7cCV9fX1haWmLr1q24fPkyjh07hr/++gtjx47Fu+++K9V57NgxbN68GRcuXICtrW2Fx+nzYi4qKsLbb7+Nzz77DKdOncLx48elfVye+Ph4tWEbpfseKBn6snnzZly+fBl5eXkICgpCTEwMLly4gIsXL+LXX38FAAwcOBDHjx/HmTNn8NNPPyE4OLjWHqOtaUyzZ8/Ga6+9hpMnT+Ls2bMoLi7G6tWrK61fp+7zTHVn2bJlSE1NxYEDB6Q/WLoiKSkJsbGx9W78bFWpVCpcu3YN7du3x4oVK3DmzBn0798fe/bs0XZoVaJSqbBkyRLs2rULvXr1wqlTp+Dn51dr4xmpYbC2tsb58+dx4sQJ/Pe//8XXX3+NNWvW4MSJE2jcuDEmT56MefPmYdasWfjuu+/g5+cn9WCXZ9SoUdDT08Ply5exatUqWFpa4sGDBzhw4ABu3rwplcvPz5d67vbt24c1a9YgLy8PxcXF+OeffwAAx48fh6enJ9q3bw8AmDx5Mt57770K121gYAADAwN4eXkhLS0Nr776Kg4cOICVK1dK7R08ePALb7cXMX78eGzatAm7d+/G999/rzaGdP/+/QgMDJR+yQsODsZXX32F8PBwtXbY2trCz89PWm737t3Izc1FbGwsgJKx6QqFolrxnThxAh4eHvDw8AAAjB07FtOmTcP169dhYWGB8PBw/PHHHxBCICcnB+7u7hg9ejQOHDiACRMmoHHjxgCASZMmSUnss4yMjODv7w8AePXVV5GWlgbg//b5K6+8AqDkS9fTvyI8z4YNGzBhwgTo6+vjzTffRGhoKC5evIh27dqhY8eOiIuLw4gRI7Bp0yZpTP/u3btx6tQpqfOnqKhIrc4333wTrVq1kt5XdpyWF3Ppl4mnn7Kcl5eHCxcuoEuXLmXa4evr+9ye4QEDBkifPW9vbxgaGsLExAQA0LFjR6SkpAAArl69irFjxyIzMxMGBgb4559/cPXqVSm+mqRpTLt378axY8cQEREBAHj06JHal8bnYfJcC+zs7JCVlQWVSgUDAwMIIZCeng57e3tth6aRlStXYteuXdi/fz+aNm2Kpk2bwsDAANnZ2VIvoVKprLftOXr0KJRKJZydnQGU/JwXEhKCxYsX61Q77O3toaenJ/WmdezYEW3atMG1a9d06vhKTEzEjRs30KtXLwAlwzPkcjnOnTunU/ujVEWfb1NTU53aN9rk7e2NlJQU3LlzBy1atCi3jL6+Prp3747u3btjxowZaNWqFZKSkuDt7Y2BAwciJCQECQkJ2LRpE7755psK17djxw54eXlh//79GDJkCF5//XW0adMGQEmSUTo8pFR6ejqmT5+OU6dOoW3btjh37px0DD+rdFjV8zxdt76+PlQqVbXqqW0TJkyAt7c3XFxcpPPn81QU69PzhBBYs2YNBgwYUGNxliciIgI5OTk4ceIEjIyMEBYWhsePH1ca37MMDQ2l+fr6+mUS16ooLCzEli1b0KhRI2zduhUA8PDhQ2zYsAErV67EpEmTEBUVhU6dOiE1NVUaJiOEwLx58xASElJuvcbGxtL/q3KcPk0IAQsLixrpxHj2+H7e8T569GisWLECw4cPBwBYWFg8dx/VVUxCCMTGxsLFxaVK9XPYRi2wsrKCt7e39JNibGws5HI5nJyctBxZ5SIiIrBt2zbs27cP5ubm0vQRI0Zg7dq1AIBTp07h+vXr6N27t5airNjUqVORlZUFpVIJpVKJbt26Yd26dZg6dapOtaNly5bo27cvfv/9dwAl39qvXr2KHj166NTxVZpsXrx4EUDJWNe0tDS4urrq1P4oVdHnW5c/+3XNyckJAQEBmDx5sjQevvQP2d9//42EhASp1w8oGW5RWFgIOzs7ACV/AAMDAzF16lSoVCq8/vrrGq23X79+mDp1KubPnw9jY2P4+vqq3X3jxo0byMzMRG5uLho1agQbGxsIIdTGg7766qs4d+4cLl26BKBkvLUm4ySf9frrr2PTpk0AgJs3b5a5g0hda926NZYvX47//Oc/Zeb169cPmzdvRkFBAVQqFdavXy8lxP369ZPGS2dlZSEuLk5abtiwYVi1ahUePnwIoCR5rO4daLp164bz588jKSkJALB9+3bY2trC1tYWd+/ehbW1NYyMjJCdnS0NvSmNLzo6GoWFhSgoKKjWo+S7deuGc+fOSb9KREdHV7rP4+Li4OjoiOvXr0t/j44fP44tW7agsLAQw4YNw6lTp7B8+XKMGzdOGu41bNgwrF27VupBLiwsxJkzZ8pdR0XHaUUxu7q6wtTUVG1bpKamSuusDXfv3pW+sEZHR7/Q2PeaMmzYMPznP/+Rkum7d+9qdI0Ke55rSWRkJAIDA7Fs2bIyB2h9lZmZidmzZ8PR0RG+vr4ASr6FnzhxAv/5z38wfvx4ODs7o3HjxoiOjkajRo20HHHV6Vo71q5di8mTJyM8PBx6enqIjIyEra2tTh1frVq1wrp16zBy5Ejo6emhuLgYX375Jezt7ev9/ggNDcWePXuQnZ2NgQMHwsTEBKmpqRVuf13aN9q2ceNGLFmyBF27doWBgQGKi4vRq1cv9O3bFykpKZg+fTru3buHJk2aQF9fH1u3boWlpaW0/KRJk7Bs2TIsXry4Sr22CxYsgJOTE06fPo3vv/8eYWFhcHd3h0wmQ7NmzRAZGYkOHTpg9OjRcHNzQ4sWLTBs2DBpeUtLS2zcuBH/8z//g8aNG2PQoEHP7T2vyOrVqzFx4kS0b98erVu3RteuXdU6LbThnXfeKXd6SEgI0tLS4O3tDaDkAq/S29itXr0agYGBaN++PWxtbdW+yISHh+PJkyfo2rWrtI/Cw8Ph5uZWaSwDBw5UOx8cP34c33//PSZMmACVSoXmzZtj586dkMlkmDlzJoYPHw43Nze0bt0a/fr1k5YLDg5GUlIS2rdvj+bNm+O1117D6dOnq7RdrKyssH79egwbNgyGhobo378/jI2NK9xfGzZsKDMOv127drC1tcXPP/8Mf39/jBw5El9//bXUuQCUDEe5c+eO9HdYpVJh0qRJ6NixY5l1eHh4PPc4rShmAwMD/PLLL5g1axZWrVqFoqIitGzZUuohf1bpmOdSrq6u0sWPmlq9ejWGDx8Oc3NzvP766/XiF7lVq1Zh7ty58PLygp6eHgwMDPD//t//q7TDg4/nJiIi0oJHjx6hUaNGMDAwwJ07d9CtWzdER0eja9eu2g6NypGXlyeNm929ezfmzZunlvTWR7oYsy5gzzMREZEWpKSkYMKECRBCoKCgAO+++y4T53pszZo12LFjB4qKimBqalq3D+WoJl2MWRew55mIiIiISEO8YJCIiIiISENMnomIiIiINMTkmYiIiIhIQ0yeiSqhUCjg6uqq9mjS8+fP10jdCQkJGDVqFICSB4Ro+zZVREREVDFeMEhUCYVCgd27d6vd47I2KJVKeHl5SQ+MICIiovqHPc9E1SSTybB06VJ07dpVSrCXL1+Ozp07w9nZGYcOHQJQcoP7gQMHonPnznBzc8OYMWPw4MEDAMChQ4dqPSknIiKimsPkmUgDo0aNUhu28ejRIwCAsbExTpw4gQ0bNmDcuHGwsbFBQkICli1bhg8//BAApCejJSQkICkpCWZmZlizZo02m0NERETVxIekEGlgx44d5fYQl45X7ty5Mx48eIDRo0cDAHx8fJCSkgIAEEJg1apV2LNnD1QqFXJzc9G9e/c6i52IiIhqDnueiV6AkZERgJLe5Wffq1QqAMDWrVtx8OBBHD58GOfPn8cHH3yAx48faydgIiIieiFMnolq2d27d9GyZUuYmpoiLy8PmzZt0nZIREREVE0ctkGkgVGjRqFJkybS+1WrVmm87IQJE/DTTz/B1dUVlpaWeO2113Dt2rXaCJOIiIhqGW9VR0RERESkIQ7bICIiIiLSEJNnIiIiIiINMXkmIiIiItIQk2ciIiIiIg0xeSYiIiIi0hCTZyIiIiIiDTF5JiIiIiLSEJNnIiIiIiINMXkmIiIiItLQ/wdrS7wvCjAGAAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 800x320 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# display timestamps\n",
     "\n",
@@ -166,7 +375,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebook/performance_demo.ipynb
+++ b/notebook/performance_demo.ipynb
@@ -33,7 +33,7 @@
    "source": [
     "out_file = \"../data/out/lang_detection_from_csv.csv\"\n",
     "# import files from csv file\n",
-    "email_list = pd.read_csv(\"../mailcom/test/data_extended/mails_lb_sg.csv\")\n",
+    "email_list = pd.read_csv(\"../data/mails_lb_sg.csv\")\n",
     "print(email_list)\n",
     "\n",
     "t_csv_read = time.time()\n",
@@ -83,8 +83,7 @@
    "outputs": [],
    "source": [
     "# write output to pandas df\n",
-    "df = pd.DataFrame(lang_out_list)\n",
-    "print(df)"
+    "df = pd.DataFrame(lang_out_list)"
    ]
   },
   {
@@ -229,7 +228,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.11.9"
   }
  },
  "nbformat": 4,

--- a/notebook/performance_demo.ipynb
+++ b/notebook/performance_demo.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -17,7 +17,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -27,41 +27,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "     Unnamed: 0                                            message\n",
-      "0           242  Von meinem iPhone gesendet Anfang der weiterge...\n",
-      "1           243  Von meinem iPhone gesendet Anfang der weiterge...\n",
-      "2           244  Von meinem iPhone gesendet Anfang der weiterge...\n",
-      "3           245  Von meinem iPhone gesendet Anfang der weiterge...\n",
-      "4           246  Von meinem iPhone gesendet Anfang der weiterge...\n",
-      "..          ...                                                ...\n",
-      "98         1313  \\nVon: Mélissa des Presses de l'Université Lav...\n",
-      "99         1314  Von: Librairie Classiques Garnier &amp;lt;libr...\n",
-      "100        1315  La langue s'enrichit #36 - FranceTerme\\nProf. ...\n",
-      "101        1316  Activités de juin - Presses de l'Université La...\n",
-      "102        1317  Nouveautés de juin\\nProf. Dr. Sybille Große I ...\n",
-      "\n",
-      "[103 rows x 2 columns]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Some weights of the model checkpoint at xlm-roberta-large-finetuned-conll03-english were not used when initializing XLMRobertaForTokenClassification: ['roberta.pooler.dense.bias', 'roberta.pooler.dense.weight']\n",
-      "- This IS expected if you are initializing XLMRobertaForTokenClassification from the checkpoint of a model trained on another task or with another architecture (e.g. initializing a BertForSequenceClassification model from a BertForPreTraining model).\n",
-      "- This IS NOT expected if you are initializing XLMRobertaForTokenClassification from the checkpoint of a model that you expect to be exactly identical (initializing a BertForSequenceClassification model from a BertForSequenceClassification model).\n",
-      "Device set to use cuda:0\n",
-      "Device set to use cuda:0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "out_file = \"../data/out/lang_detection_from_csv.csv\"\n",
     "# import files from csv file\n",
@@ -82,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,43 +78,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                                               content  langid  \\\n",
-      "0    Von meinem iPhone gesendet Anfang der weiterge...  fr-1.0   \n",
-      "1    Von meinem iPhone gesendet Anfang der weiterge...  fr-1.0   \n",
-      "2    Von meinem iPhone gesendet Anfang der weiterge...  fr-1.0   \n",
-      "3    Von meinem iPhone gesendet Anfang der weiterge...  fr-1.0   \n",
-      "4    Von meinem iPhone gesendet Anfang der weiterge...  fr-1.0   \n",
-      "..                                                 ...     ...   \n",
-      "98   \\nVon: Mélissa des Presses de l'Université Lav...  fr-1.0   \n",
-      "99   Von: Librairie Classiques Garnier &amp;lt;libr...  fr-1.0   \n",
-      "100  La langue s'enrichit #36 - FranceTerme\\nProf. ...  fr-1.0   \n",
-      "101  Activités de juin - Presses de l'Université La...  fr-1.0   \n",
-      "102  Nouveautés de juin\\nProf. Dr. Sybille Große I ...  fr-1.0   \n",
-      "\n",
-      "                langdetect                  trans  \n",
-      "0     fr-0.999997643017964  fr-0.9911757707595825  \n",
-      "1    fr-0.9999985698658455  fr-0.9899152517318726  \n",
-      "2     fr-0.999996534677391  fr-0.9927849769592285  \n",
-      "3    fr-0.9999966462358008  fr-0.9916396737098694  \n",
-      "4    fr-0.7142828117950524  fr-0.9849207997322083  \n",
-      "..                     ...                    ...  \n",
-      "98   fr-0.9999957490263667  fr-0.9911774396896362  \n",
-      "99   fr-0.9999943212158026   fr-0.990962564945221  \n",
-      "100  fr-0.9999963877653447  fr-0.9920682907104492  \n",
-      "101  fr-0.9999945178087889  fr-0.9914606809616089  \n",
-      "102  fr-0.9999946157595117  fr-0.9915869235992432  \n",
-      "\n",
-      "[103 rows x 4 columns]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# write output to pandas df\n",
     "df = pd.DataFrame(lang_out_list)\n",
@@ -155,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -165,29 +99,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "fr-0.9913384914398193\n",
-      "fr-0.9913080334663391\n",
-      "fr-0.9910556077957153\n",
-      "fr-0.9912301301956177\n",
-      "fr-0.9908391833305359\n",
-      "fr-0.9915818572044373\n",
-      "fr-0.9918330907821655\n",
-      "fr-0.9908162355422974\n",
-      "fr-0.9911774396896362\n",
-      "fr-0.990962564945221\n",
-      "fr-0.9920682907104492\n",
-      "fr-0.9914606809616089\n",
-      "fr-0.9915869235992432\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for item in df[\"trans\"][90:104]:\n",
     "    print(item)"
@@ -195,17 +109,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "You seem to be using the pipelines sequentially on GPU. In order to maximize efficiency please use a dataset\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# loop over mails and pseudonymize them\n",
     "out_list = []\n",
@@ -242,43 +148,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "                                               content  \\\n",
-      "0    Von meinem iPhone gesendet Anfang der weiterge...   \n",
-      "1    Von meinem iPhone gesendet Anfang der weiterge...   \n",
-      "2    Von meinem iPhone gesendet Anfang der weiterge...   \n",
-      "3    Von meinem iPhone gesendet Anfang der weiterge...   \n",
-      "4    Von meinem iPhone gesendet Anfang der weiterge...   \n",
-      "..                                                 ...   \n",
-      "98   \\nVon: Mélissa des Presses de l'Université Lav...   \n",
-      "99   Von: Librairie Classiques Garnier &amp;lt;libr...   \n",
-      "100  La langue s'enrichit #36 - FranceTerme\\nProf. ...   \n",
-      "101  Activités de juin - Presses de l'Université La...   \n",
-      "102  Nouveautés de juin\\nProf. Dr. Sybille Große I ...   \n",
-      "\n",
-      "                                              det_lang  \n",
-      "0    [(fr, 0.9911757707595825), (ru, 0.000684742582...  \n",
-      "1    [(fr, 0.9899152517318726), (ru, 0.000784482806...  \n",
-      "2    [(fr, 0.9927849769592285), (tr, 0.000568731455...  \n",
-      "3    [(fr, 0.9916396737098694), (ru, 0.000675349729...  \n",
-      "4    [(fr, 0.9849207997322083), (en, 0.001657419255...  \n",
-      "..                                                 ...  \n",
-      "98   [(fr, 0.9911774396896362), (ru, 0.000708585081...  \n",
-      "99   [(fr, 0.990962564945221), (ru, 0.0007254832307...  \n",
-      "100  [(fr, 0.9920682907104492), (ru, 0.000636541168...  \n",
-      "101  [(fr, 0.9914606809616089), (ru, 0.000670765293...  \n",
-      "102  [(fr, 0.9915869235992432), (ru, 0.000665231840...  \n",
-      "\n",
-      "[103 rows x 2 columns]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# write output to pandas df\n",
     "df = pd.DataFrame(out_list)\n",
@@ -287,27 +159,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Total time: 00:10\n"
-     ]
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAs8AAAE3CAYAAABVW6xeAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAMTgAADE4Bf3eMIwAAUVpJREFUeJzt3XdYFFffP/73AgoqTRQEWWBFSpQioqJRoxJrEkUfsMVKlKLRqMFENNFbzW27vzEYY4oYFaPEEsEYEk3yWLDkjg0jKtiAuAIKokYRbLBwfn/wYx5XEBYElsX367r20p05c+ZzZmaHz549MyMTQggQEREREVGl9LQdABERERGRrmDyTERERESkISbPREREREQaYvJMRERERKQhJs9ERERERBpi8kxEREREpCEmz0REREREGmLyXEXGxsY4dOhQna/Xzc0N3333XZ2vtyLvv/8+rKysYGxsjPPnz2s7nBf29L49dOgQZDIZVCqVdoOqApVKBZlMVqXjUyaTYf/+/dWe/6Kejfno0aMwNjZGUVFRra2ztvTs2ROLFi167vzCwkKMHTsWFhYWMDY2Rm5urtrnWqlUQiaTITU1tY4irr79+/dDJpNJ75ctW4YBAwZoMSIiorqjcfJ8/vx5jB49GjY2NjA2NoZCocDbb7+Nv/76qzbjqxHVSQA2bdoEuVxeZnp+fj769OlTQ5GV9bykLTk5GRMnTqy19VbVsWPH8PXXX+PMmTPIz8+Hh4eHtkN6YbW9b6lyr732GvLz86Gvr6/tUGpcTEwM4uPjoVQqkZ+fDzMzs3r3ua6ujz76CP/7v/+r7TCIiOqERsnzoUOH4OPjg1atWuHYsWPIy8tDYmIi+vfvj507d9Z2jFQPpaWlwdLSEra2ttWuo6CgoAYjIqrf0tLS4OjoCFNT0zpbZ2FhYZ2ti4joZaFR8hwaGorhw4dj9erVUCgUkMlkMDc3x6RJk7B8+XKp3KZNm+Du7g5TU1O4u7urDTMo/Uly48aN8PT0RLNmzdCzZ09kZmbiyy+/hIODA8zNzREaGqr2k61MJkNERAS6dOkCY2Nj+Pj4ICEhQZofGBiIcePGqcXbp08fzJ8/H0DJcAcAGDJkCIyNjfHGG28AAHbu3IlOnTqhefPmaNmyJfz8/HD16lUAJT8dT5kyBTdu3ICxsTGMjY3x/fffS/E83Yu9Z88edOrUCWZmZnBxccHKlStRXFysFv+aNWvQo0cPGBsbw8PDA3/88Ue52zk9PV2Kz9zcHMbGxli2bBkAQKFQYP369S+0La9fv44xY8bA1tYWVlZWePvtt3Hr1i1p/pdffom2bdvCxMQErVq1QmBgYLlxLly4EEFBQdL2Kd3G9+7dQ0hICORyOVq2bIk33ngDly9flpZbtGgRevbsiQULFqB169bw8vIqt/6ioiJ89tlnaNeuHczMzNCpUyccOHBAml/6q8DXX38NBwcHNGvWDIGBgcjLy8PUqVPRokUL2NjYIDIyUlomKysLgwcPRqtWrWBiYgJPT88yX/wq+oUiPj4enTt3hpmZGVq0aIEePXrg7t275ZZ9VnX318WLF/HGG2+gZcuWkMvlCA0NRW5urjQ/JycH/v7+MDc3h6OjI3bs2FFm3SdOnECfPn3QokULODg4YMGCBS80FKWy4z0kJAQKhQLGxsZo06YNFi5cqDa/spif/eWl9JhZvHgxbGxsYGFhgdDQULU2nDx5El26dIGJiQk6d+6MiIgItSEFz9L0WKjoc6tSqTBnzhxYW1vD0tIS8+bNq3C7BQYG4pNPPsGxY8fUzkNPf67Ls3fvXnTt2hXNmzeHs7MzvvjiiwrXo1AosHDhQgwaNAgmJib47LPPAACbN29Ghw4dYGZmBjc3N2zfvr1K2+P06dPo2rUrjI2N0blzZ5w7d05tful+KtWnTx/MnDkTY8aMgZmZGezs7PDNN9+oLRMVFQUnJyeYmJjA398f06dP5y8/RKQbRCWuXLkiAIj//d//rbBcTEyMMDExEfv37xcqlUrs27dPNGvWTPz4449CCCGuXr0qAIj+/fuLmzdviry8PNGjRw/h4uIi5syZIx4/fixSUlKEmZmZ2Lp1q1QvANG2bVuRnJwsHj9+LBYuXChatmwp7t27J4QQYuLEiWLs2LFqsfTu3Vt8/PHHanXs27dPrcyvv/4qEhMThUqlErdu3RKDBw8W3bp1k+ZHRUUJW1vbMu18uq6TJ0+KRo0aiR07dojCwkKRkJAgbGxsxKpVq9TKe3p6ipSUFFFYWChmzpwp7O3tn7sd4+PjBQBRWFioNt3BwUF8++231d6Wjx8/Fq6urmL27NkiPz9f5OXliXHjxol+/foJIUr2c5MmTcT58+eFEELk5eWJw4cPPzfO8rbP4MGDRZ8+fURWVpZ48OCBmDlzppDL5SIvL08IIcTChQuFvr6+WLx4sXj06JF48OBBuXUvXLhQdOjQQVy6dEkUFRWJXbt2iaZNm4rU1FRp3fr6+mL27Nni0aNHIi0tTTRv3ly0a9dO7Nq1S6hUKrFz505hYGAg0tPThRBCZGRkiNjYWJGXlycKCgrE+vXrhYGBgUhKSip33z67H1q3bi02btwoiouLxZMnT8Sff/4p8vPzn7t9nlad/XX//n3RunVrERYWJh48eCBu3LghevXqJYYOHSrV279/fzFw4EBx584dcefOHfHWW28JACI+Pl4IIcSlS5dEs2bNxLZt20RhYaFQKpXC09NTLFmypNw2l6eqx/u3334rsrOzRXFxsTh27JiwsLAQa9eu1TjmZ7f7woULhYGBgfj000/FkydPxOXLl0Xz5s3Fxo0bhRBC3L17V1hYWIjFixeLJ0+eiIsXLwpnZ2dR0alN02Ohos/t0qVLhYODg3Remj9/vjAwMBALFy587noXLlwoevTooTatvM91SkqKEEKIgwcPCjMzM7F//35RVFQkzp8/L+RyuYiOjn7uOhwcHESrVq3En3/+KYqLi8WDBw9EVFSUsLOzE6dOnRJFRUXi6NGjwsTERBw9elSj7ZGbmytatmwp5s+fLx4/fiySk5NF27Zt1bbxs23r3bu3MDU1FQcOHBBFRUUiJiZG6OnpSW07fPiwaNy4sdi7d69QqVRiz549okmTJqJ3797PbRsRUX1RafL8xx9/CADiwoULFZYbMGCAmDVrltq0GTNmiIEDBwoh/u8Pw5EjR6T5n3/+uWjatKlQqVTStMGDB6vVA0B88cUX0vuioiJhbW0tNm/eLISofvL8rL/++ksAEPfv3xdCaJY8h4SEiGHDhqnNj4iIEK6urmrlv/vuO+l9UlKSACCys7PLjaMqyXNVtmVsbKxo3bq1KC4uluZnZmYKACIjI0P8/fffwsjISGzfvl3k5uZWsKVKPLt9bty4IQCIxMREaVpBQYFo0aKF2LZtmxCi5A/sszGUx9TUVPz2229q0/r16yf+/e9/S+s2NDQUBQUF0vxhw4aJAQMGqC1jYmIidu/e/dz1eHp6qh1bFSXPCoVCfPzxxyIzM7PC2MtTnf21detW0bJlS7XjoPQYzcrKkvbduXPnpPnnzp1TS0Tfe+89MXr0aLVYoqOjRdu2bcttc3mqerw/a8aMGcLf318IITSKubzkuU2bNmp1Dh8+XEyZMkUIIcSWLVtEq1atRFFRkTR/zZo1FSbP5SnvWKjoc+vk5KRWXqVSCUtLyxpNnocMGSLmzp2rVn7JkiWib9++z12Hg4NDmWU8PDzUvsAIIURQUJCYPHnyc+t5entER0cLKysrtWP1iy++qDR5fuedd9TqbNmypdi+fbsQQojJkyeLESNGqM0PCAhg8kxEOqHSYRtWVlYAgMzMzArLZWRkoG3btmrTnJyckJ6erjbNxsZG+n+zZs1gaWmpdnFQs2bNkJeXp7ZMmzZtpP/r6enBwcEBGRkZlYVeocOHD6Nv376wsbGBqakpevfuDaDkZ2VNadrm1q1bS/9v1qwZAJRpY3VUZVumpKTg5s2baN68OczNzWFubg43NzcYGhoiPT0dbdq0wfbt2xEVFQV7e3t06dIF27Zt0ziW0v3x9PZo1KgRHBwc1LaHg4NDhT+p37x5E/fv38eIESOkOM3NzfHnn3/i+vXrUrmWLVuiUaNGam19ensAQNOmTaX23717F8HBwWjTpg1MTU1hbm6O5ORkjfd3XFwc/v77b3Tq1AlOTk5YuHBhlYc/VGV/ZWRkwMHBAQYGBtJ8JycnACXDe0o/j09/Np7+P1Cyz3/88Ue17Th16lRkZ2dXKe5SlR3vQggsXboUbm5u0nEWGRkpbWNNYi7P058fQH07Xb9+HXZ2dtDT+79TmUKhqLA+TY+Fij63mZmZarHr6+vD3t6+0rZURUpKClavXq22/1asWIGsrKwKlyvvOJg9e7ZaPdu2bcONGzcAVL49MjMzYWdnp3as1sR+c3BwUJtf2X4jIqovKk2enZ2d4eLigi1btlRYzs7ODmlpaWrT0tLSauQPilKplP5fXFyM9PR06U4YJiYmePDggVr50j8KpZ5N1goKCjB48GAMGjQIV65cwf3793H48GEAJQkAALU/xs9TG23WZL3VYW1tDQcHB9y7d0/t9fjxY3Tv3h0AMHToUPz222+4ffs2PvzwQ4wdOxZXrlzRqH47OzsAUNseKpUK6enpatujsvaZm5vDyMgIv/zyi1qcDx48KDNmsirmzp2LS5cu4fDhw8jNzcW9e/fg5uYm7e/KeHh4YOvWrcjOzkZMTAzWrl2LqKioasdTGTs7O6Snp6sl6KXb1t7eXjr+n/5sPP1/oGSfjxkzRm073r9/H/n5+dWOqaLjffv27fj888+xefNm3L59G/fu3UNoaKi0jTWJuapsbW2RkZGhNq762rVrFS7zoscCUNKWp2MvKip64S/0z7K2tsbcuXPV9l9eXh6Sk5MrXO7Zz5i1tTW+/vprtXry8/Oxd+9eAJVvD7lcjoyMDLXx+DWx357dT5XtNyKi+kKjTC0yMhI7d+5EWFgYrl27BiEE7t+/j82bN+Pjjz8GAAQFBWHjxo04dOgQioqKcPDgQWzYsAEhISEvHOTq1atx8eJFFBQUYOnSpSgoKICfnx8AoHPnzoiPj8elS5dQWFiIzz//XLrwr5S1tbXahWsFBQV49OgRmjdvDhMTE9y4cUO6wPDpZW7fvo07d+48N65JkyZhz549iI2NRVFREc6cOYNPP/30hdpsbW0NAGrx1gR/f38UFhZiwYIF0kVnOTk50gVbly9fxt69e5Gfnw8DAwOYmZkBgMa3DLOxscGbb76J2bNn4+bNm3j06BHCw8PRuHFjvPXWWxrHaWhoiClTpmDOnDm4ePEihBB49OgRjhw5onEiX57c3Fw0bdoULVq0QGFhIdasWVNpElKqoKAAUVFR0sWVZmZm0NfXl3qFSy9ye9GE4mlvvfUWDAwM8NFHH+HRo0fIzs7G+++/jyFDhsDa2hq2trbo27cv5syZg7t37+Lu3bv46KOP1Op49913ERMTg507d6KgoABFRUVITU3Fb7/9Vq2YKjvec3NzYWBgACsrK8hkMsTHxyM6OlpaXpOYq2rw4MEoKCjA8uXLUVBQgCtXrlR6Ud2LHAulJk6ciM8++wyXLl3CkydP8Mknn+Cff/55kaaUMXPmTKxZswYHDhyASqWCSqVCUlISjhw5UqV6Zs2ahX//+984deoUiouL8eTJE5w6dQqnT58GUPn2GDx4MIqKivDJJ5/gyZMnuHTpElavXv1CbRs/fjx++ukn/P777ygqKsJvv/0mJfNERPWdRslznz59cOLECVy/fh0+Pj7SFdm//fYbhg8fDgAYMWIEPvvsM7z77rswNzfHe++9h9WrV8Pf3/+Fg5w6dSrGjx8PCwsLxMXFYe/evTA3NwcAjB07FqNHj0b37t1hZ2eHe/fuoUePHmrLL1++HP/5z39gbm6OwYMHw9jYGOvXr8eSJUukK99HjBihtszrr7+OoUOHwsXFBebm5ti6dWuZuLp27YqYmBgsXboUzZs3x4gRIzBjxgzMnDmz2m11cXHBe++9B19fX+ln2ppgYmKCY8eOIT09HR4eHjA1NUX37t2lP8SlX0xsbW1hamqK2bNnY/PmzWV+pq/Ili1boFAo4O3tDblcjuTkZOzfvx8mJiZVinXlypV4++23paEbCoUCy5cvf6Hbbi1ZsgSPHj1Cq1atoFAocPPmzTLHSUViYmLg5uaGZs2aoXfv3ggMDJTuz3vt2jU4OTm90G37nmVqaop9+/bh7NmzkMvl0nCRp+9gEx0djcaNG0vbfNSoUWp1dOnSBfv27cO3334LW1tbtGjRAsOHD692D19lx3tgYCD69u0LDw8PtGzZEmvXri1zJ5zKYq4qc3Nz7N27Fz/++CMsLCwwZswYTJo0CYaGhs9d5kWPBQAIDw+Hv78/evfuDblcjoKCAnTt2vWF2vKsYcOGYcuWLfjXv/4FKysrWFlZISgoCLdv365SPTNnzsSiRYswZcoUWFhYwNbWFh9++KH0i11l28PMzAx79+7F3r170aJFC4wbNw5Tp059obb17t0bX3/9tfT3IjIyEmPHjoWRkdEL1UtEVBdkoiq/VWqBTCbDvn370K9fP22HQlSusWPHYtiwYWW+gJF2fP755/jmm29q/Ncbql3Dhg1Dq1at1G4xSURUHxlUXoSIKlJ6D3DSjgMHDsDFxQVyuRynT5/GypUra2S4GNWu2NhY9O/fH02aNMGuXbvwyy+/4ODBg9oOi4ioUkyeiUinXbp0CePHj8e9e/dgZWWFcePGITw8XNthUSV+/vlnBAcHo6CgAA4ODti4cSN69eql7bCIiCpV74dtEBERERHVF7VzXzQiIiIiogaIyTMRERERkYY45llDhoaGsLS01HYYRNSA3bp1C0+ePNF2GLWG51Eiqm11cR5l8qwhS0vLSh9RTkT0IkqfwthQ8TxKRLWtLs6jHLZBRERERKQhJs9ERERERBpi8kxEREREpCGOeSaqAUII6UX0PDKZDHp67LMgItJlTJ6JXkBxcTFycnJw7949Js6kkUaNGsHe3h6NGzfWdihERFQNTJ6JXsC1a9egp6cHhUKBRo0aaTscqueEELhz5w7S09Ph5OSk7XCIiKgadCp5TklJwcSJE3H79m2YmZlh06ZNcHNzUyujVCoRGBiIM2fOoE2bNkhMTCxTjxACffv2xV9//YV79+7VTfDU4BQXF+Px48dwdnaGgYFOfZRIi1q0aIF//vkHxcXFHMJBRKSDdOrMHRoaipCQEFy5cgXh4eEIDAwsU8bU1BRLlizB1q1bn1vPqlWr0LZt21qMlF4GpcM0ZDKZliMhXVJ6vHCYDxGRbtKZ5DknJwcJCQkYN24cACAgIAAZGRlITU1VK2dhYYGePXuiWbNm5daTnJyM3bt3Y+7cubUeMxERERE1LDrzW3NGRgZsbGykn8dlMhns7e2rNHawsLAQwcHB2LBhA/T19SssGxERgYiICOl9fn5+9YOnl4pi7p5aqVe54i3N1q9QwNDQEE2aNEFBQQGmTZuGadOmVX+9SiXatm0LDw8PCCFgYGCAlStXwtfXt9p11oYbN25g1KhROHr0qLZDISKiBkxnkueasHjxYvj7+6Ndu3ZQKpUVlg0LC0NYWJj0vlqPe1xkBizKrfpyRC9ox44d8PLywrVr1+Dp6YnXXnsNnp6eAErGagOo0nhbExMT6fqBXbt2YeTIkcjJyVEbsqJSqbQ69rt169ZMnOvQ01/SAGDevHkYNWqUlqOiulRbHQXaoGnnBBGgQ8M27OzskJWVBZVKBaBkvGB6ejrs7e01ruPw4cNYs2YNFAoFevbsifv370OhUODWrVu1FTaRVjk4OMDV1RVjxoxBQEAABg4cCHd3d2RlZeH3339Hz5490alTJ/j4+CA+Pl6jOgcNGoTbt2/jzp076NOnD2bMmIFXX30VAwYMQFFRET788EO4u7vD3d0d7733HgoKCgAAubm5CAoKgru7Ozp06IBJkyYBKPlFaO7cufDx8YGXlxdGjhyJu3fvAgDWr1+P9u3bw8vLCx4eHjhx4gSKi4sxffp0tGvXDh06dECnTp3w+PFjKJVKmJubS3HKZDIsW7YMPj4+aNOmDaKioqR5f/75p1TnpEmT0KFDBxw6dKhmNvpLZMeOHUhMTERiYiITZyJ6aehMz7OVlRW8vb0RHR2NwMBAxMbGQi6XV+l2T0/3SimVSnh5eVXaA02ky86fP49Lly5hyJAhiI+Px5kzZ9CqVSv8/fffWLRoEX7//XeYmpoiNTUVr732GpRKJQwNDSusc9u2bbC3t0fLli0BAFeuXMGRI0fQqFEjfPPNNzh16hROnz4NfX19+Pn5YdWqVQgPD8esWbPQpEkTnDt3Dnp6etKX1k8//RTNmjXDyZMnAQD//ve/MX/+fHz11VeYPXs2Ll26BBsbGxQWFuLJkyc4e/YsDhw4gOTkZOjp6SE3N/e590w2NDTEyZMncenSJXTp0gXjx49HcXExRo0ahc2bN8PX1xfx8fFqiTUREVFFdCZ5BoDIyEgEBgZi2bJlMDU1lf7gBQUFwc/PD35+fnj48CFcXFzw5MkT5ObmQi6XY/z48Vi+fLmWoyeqO6NGjUKTJk3QtGlTbNy4EUlJSWjSpAlatWoFAPjtt9+QmpqKXr16Scvo6ekhPT0dzs7OZerLy8uDl5cXAMDW1hZxcXHSvHHjxkn3uN6/fz8CAwOlBDw4OBhfffUVwsPD8csvv+DEiRPScBFLS0sAwO7du5Gbm4vY2FgAQEFBARQKBQCgb9++GD9+PIYMGYI33ngDLi4ucHR0hEqlwqRJk+Dr64u33nrruUNQxo4dCwB45ZVXYGBggOzsbPzzzz8wMDCQxmz7+vry7jvVNGHCBAgh4OPjgxUrVkj7lIioIdOp5NnV1RXHjh0rM339+vXS/5s2bYrMzMxK61IoFLzHMzVYpWOeSyUlJcHY2Fh6L4RA//79y72l44wZM3DkyBEAwJYtW2BiYqI25vlZT9f7LE1u4yeEwJo1azBgwIAy82JjY3H69GkcOnQIb775JpYsWYLRo0cjKSkJhw8fRnx8PObNm4cjR46UO97ayMhI+r++vr407Ks6cZK6I0eOwN7eHoWFhZg/fz4mTpyIvXv3qpXhhddE1BDpzJhnIqo5AwcOxP79+3Hu3DlpWumwiS+++EIax+rh4VGlevv164fNmzejoKAAKpUK69evl5JiPz8/rFy5UrpgsXTYxrBhw7Bq1So8fPgQAPDw4UMkJydDpVIhLS0NnTt3xgcffIDhw4fj5MmTuHXrFh48eIABAwZg2bJlUCgUuHDhgsYxurq6orCwEIcPHwZQci3Es7e8pMqVXm/SqFEjzJo1q9yLNcPCwpCZmSm9KvqiRUSkK3Sq55lIF+jCVdtOTk7YunUrQkND8fDhQxQUFKBjx44VPlxIEyEhIUhLS4O3tzcAoE+fPpg1axaAkocTvf/++/Dw8ECjRo3QpUsXfPvttwgPD8eTJ0/QtWtXqQc4PDwcTk5OmDRpkjTMwtLSElFRUcjIyEBwcDAKCwtRVFSEHj164I033sD169c1itHQ0BDbt2/HtGnTUFxcjE6dOsHV1VXtYkOq2IMHD1BYWChts23btqFjx47aDYqIqI7IBB9zpRG5XK7RcBA1vFVdg1ZUVIQrV67AxcWl0vuGU/2Sl5cHExMTAMCpU6fg5+eHtLQ0NG3atNbXXdFxU63zjBb8/fffCAgIQFFREYQQcHR0xOrVq6Wx6s+jK+0jzfBWdVQf1cV5hj3PRPTSiY2NxapVq6SHvmzZsqVOEueGwtHREWfOnNF2GEREWsHkmYheOoGBgQgMDNR2GEREpIN4wSARERERkYaYPBMRERERaYjJMxERERGRhpg8ExERERFpiBcMEtW0RWa1VK9mtz1UKBQwNDREkyZNUFBQgGnTpmHatGm1E9P/b/jw4Rg8eLDWL8JLSEjAp59+ih07dlRr+cTERFy6dAmjR4+Wpnl5eeHo0aPSre2IiOjlxp5nogZox44dSExMxK+//oqPPvpI7UmCDVnnzp2rnTgDJcnz9u3by0xj4kxERKWYPBM1YA4ODnB1dcXZs2fh6ekJLy8vuLu746effgIAZGdnY+TIkfDx8YGHhwfmz58vLatQKJCYmCi979y5Mw4dOgQAuHTpErp37w43NzcMGzYM9+/fl8rl5OTA398fHh4ecHd3R2RkpFqd//rXv/Dqq6+iTZs2WLJkCYCSHuNXXnkFTz+zqXv37vj111+hVCphbm6OBQsWwNvbG87Ozvjvf/+L999/X2pPUlISAODQoUPw8vICAKxfvx5eXl7SS19fH4cPH0Z2djZ8fX3RqVMnuLm5Yfr06SguLkZOTg7+9a9/IT4+Hl5eXpgyZQoAQCaT4d69e1Kc3bt3h6enJ3x8fPDf//4XAKQYFy5ciE6dOsHJyQl79+6tgT1IRET1DZNnogbs/PnzuHTpEqZMmYLIyEgkJibi3Llz6N27NwBg4sSJmDZtGk6ePIkzZ84gISEBO3furLTe8ePHY/LkyUhOTsa///1vHD58WJr33nvvwdXVFefPn8fBgwexZMkSHD9+XJp/7949HDt2DKdOncKnn36K69evo3PnzmjRogX27dsHADhz5gxu3bqFQYMGAQByc3PRqVMn/PXXX5g7dy4GDhwIPz8/JCYmYuLEiVi8eHGZGIOCgpCYmIjExESMGDEC/fr1Q48ePWBubo6ff/4Zp0+fxrlz56BUKvHDDz/AysoKn3zyCXx9fZGYmIi1a9eq1VdQUAB/f38sXLgQ586dQ0REBAICApCfny/F6OnpidOnT+PLL7/E+++/X8W9RUREuoBjnokaoFGjRqFJkyZo2rQpNm7ciD///BMzZ87E8OHDMWDAAHh5eeHBgwc4cOAAbt68KS2Xn5+Py5cvV1j3/fv3kZiYKI1v9vDwQM+ePaX5+/fvx+nTpwEAVlZW8Pf3x/79+9GtWzcAwJgxYwAALVu2hKOjI65evQpbW1vMnDkTX375JQYMGICvvvoK7777LmQyGQDAyMgIw4YNA1DSA25sbAxfX18AgI+PD77//vvnxrtlyxbExsbi8OHDMDAwQEFBAcLDw/HHH39ACIGcnBy4u7urjXMuz+XLl6Gnp4eBAwcCAHr27IlWrVohMTERcrkcRkZG8Pf3BwC8+uqrSEtLq7A+IiLSTUyeiRqgHTt2SMMXgJIL+pKTkxEfH4+JEydi7NixePfddwEAx48fh5GRUZk6DAwMUFRUJL1//Pjxc9dXmuRqMu/pdenr60OlUgEA/P39MWfOHJw5cwZxcXFYuXKlVM7Q0FBtmefV8ayDBw/ik08+wZEjR6RxyxEREcjJycGJEydgZGSEsLCwCttWkafbZmhoKL3X19dX23ZERNRwcNgG0Uvg0qVL0vjeqVOn4vjx41Lv7YoVK6RyN27cQGZmJgDAyckJJ06cAACcPHlS6pE2NTVFx44dsXnzZgBAcnIy/vjjD6mOfv364dtvvwUA3Lp1C7t27UL//v0rjdHAwABTpkyBn58f/ud//gfm5uYv1Obz589j0qRJ2L17N2xsbKTpd+/ehbW1NYyMjJCdna02TMXU1BS5ueXf1cTV1RXFxcXS0JI///wT2dnZal9SiIio4WPyTPQS+Oijj+Dm5oaOHTtiy5YtWLRoEQDg+++/R2pqKtzd3eHh4QF/f3/cuXMHALBkyRJ89dVX6NChAzZu3Ag3Nzepvs2bN2PdunVwd3fH/Pnz0atXL2neF198gYsXL8LDwwO+vr74+OOP0bVrV43inDx5Mq5fv47p06e/cJsjIiLw4MEDjB07VrpoMCEhATNnzsSJEyfg5uaG8ePHo1+/ftIyffv2xZMnT+Dp6SldMFiqcePG2LVrFxYuXAhPT0/MmjULMTExMDY2fuFYiYhId8jE05e303PJ5XKpR05ji8w0vjcv6Z6ioiJcuXIFLi4u0NfX13Y4DUJMTAy++eYbHDhwQNuh1JqKjptqnWd0SENv38tGMXePtkOoMcoVb2k7BKohdXGe4ZhnIqoXBg0ahCtXruDHH3/UdihERETPxeSZiOqF3377TdshEBERVYpjnomIiIiINMTkmaiaSm9LxssGqCpKj5eKbu9HRET1F4dtEFWTnp4ejIyMcP36dbRq1QqNGjXSdkhUzwkhcOfOHTRq1Ah6euy7ICLSRUyeiV6Ag4MDcnJyoFQq2QNNGmnUqBHs7e21HQYREVWTTiXPKSkpmDhxIm7fvg0zMzNs2rRJ7d6zAKBUKhEYGIgzZ86gTZs2SExMlOYdPHgQc+fORX5+PmQyGd566y2sWLGCPUBUbXp6erC2tkarVq0ghGACTRWSyWQ83xAR6TidSp5DQ0MREhKCwMBAxMTEIDAwEKdOnVIrY2pqiiVLliA3Nxcff/yx2rzmzZtj+/btcHR0xOPHj9GvXz9s3rwZgYGBddgKaohkMhnHsBIREb0EdKYLJCcnBwkJCRg3bhwAICAgABkZGUhNTVUrZ2FhgZ49e6JZs2Zl6ujYsSMcHR0BAEZGRvDy8oJSqaz12ImIiIioYdCZ5DkjIwM2NjYwMCjpLJfJZLC3t0d6enq16svOzkZMTAwGDx5ck2ESERERUQOmM8lzTbp//z6GDBmCOXPmoHPnzuWWiYiIgFwul175+fl1HCURERER1Tc6kzzb2dkhKysLKpUKQMktn9LT06t81XpeXh4GDRqEoUOHIiws7LnlwsLCkJmZKb2MjY1fKH4iIiIi0n06kzxbWVnB29sb0dHRAIDY2FjI5XI4OTlpXEd+fj4GDRqEQYMGYf78+bUVKhERERE1UDqTPANAZGQkIiMj4eLighUrViAqKgoAEBQUhLi4OADAw4cPIZfLMWLECFy4cAFyuRzz5s0DAKxevRonT57Erl274OXlBS8vLyxdulRr7SEiIiIi3SITvDGtRuRyOTIzM6u20CIzYFFu7QRERA1Otc4zOqSht+9lo5i7R9sh1Bjlire0HQLVkLo4z+hUzzMRERERkTYxeSYiIiIi0hCTZyIiIiIiDTF5JiIiIiLSEJNnIiIiIiINMXkmIiIiItIQk2ciIiIiIg0xeSYiIiIi0hCTZyIiqraoqCjIZDLs3r1b26EQEdUJJs9ERFQtSqUS3377Lbp166btUIiI6gyTZyIiqrLi4mIEBQVhzZo1MDQ01HY4RER1hskzERFVWUREBHr06IFOnTppOxQiojploO0AiIhItyQlJSE2NhZHjhypsFxERAQiIiKk9/n5+bUdGhFRrWPPMxERVcnRo0ehVCrh7OwMhUKB48ePIyQkBN98841aubCwMGRmZkovY2NjLUVMRFRzmDwTEVGVTJ06FVlZWVAqlVAqlejWrRvWrVuHqVOnajs0IqJax+SZiIiIiEhDHPNMREQv5NChQ9oOgYiozrDnmYiIiIhIQ0yeiYiIiIg0xOSZiIiIiEhDTJ6JiIiIiDTE5JmIiIiISENMnomIiIiINMTkmYiIiIhIQ0yeiYiIiIg0pFPJc0pKCrp37w4XFxd06dIFycnJZcoolUr06dMHZmZm8PLyKjN/w4YNcHZ2Rtu2bREcHIzCwsI6iJyIiIiIGgKdSp5DQ0MREhKCK1euIDw8HIGBgWXKmJqaYsmSJdi6dWuZeVevXsWCBQtw9OhRpKam4ubNm1i3bl0dRE5EREREDYHOJM85OTlISEjAuHHjAAABAQHIyMhAamqqWjkLCwv07NkTzZo1K1NHTEwM/Pz8YG1tDZlMhilTpmDbtm11Ej8RERER6T6dSZ4zMjJgY2MDAwMDAIBMJoO9vT3S09M1riM9PR0ODg7Se4VCUaXliYiIiOjlpjPJc12LiIiAXC6XXvn5+doOiYiIiIi0TGeSZzs7O2RlZUGlUgEAhBBIT0+Hvb29xnXY29vj2rVr0nulUvnc5cPCwpCZmSm9jI2NX6wBRERERKTzdCZ5trKygre3N6KjowEAsbGxkMvlcHJy0riOgIAAxMXFITs7G0IIrF27FqNHj66tkImIiIiogdGZ5BkAIiMjERkZCRcXF6xYsQJRUVEAgKCgIMTFxQEAHj58CLlcjhEjRuDChQuQy+WYN28eAMDR0RGLFy9Gjx494OTkBEtLS4SGhmqtPURERESkWwy0HUBVuLq64tixY2Wmr1+/Xvp/06ZNkZmZ+dw6goODERwcXCvxEREREVHDplM9z0RERERE2sTkmYiIiIhIQ0yeiYiIiIg0xOSZiIiIiEhDTJ6JiIiIiDTE5JmIiIiISENMnomIiIiINMTkmYiIiIhIQ0yeiYiIiIg0xOSZiIiIiEhDTJ6JiIiIiDTE5JmIiIiISENMnomIiIiINMTkmYiIiIhIQ0yeiYiIiIg0xOSZiIiIiEhDTJ6JiIiIiDTE5JmIiIiISENMnomIiIiINMTkmYiIiIhIQ0yeiYiIiIg0ZKDtAIiISPcMGDAA2dnZ0NPTg4mJCb744gt07NhR22EREdU6Js9ERFRlP/zwA8zNzQEAP/74IwIDA3H27FntBkVEVAc4bIOIiKqsNHEGgNzcXMhkMu0FQ0RUh9jzTERE1TJhwgTEx8cDAPbu3VtmfkREBCIiIqT3+fn5dRYbEVFt0ame55SUFHTv3h0uLi7o0qULkpOTyy23YcMGODs7o23btggODkZhYSEAoLi4GGFhYWjfvj08PT3h6+uL1NTUumwCEVGDsXnzZmRkZGDJkiUIDw8vMz8sLAyZmZnSy9jYWAtREhHVLJ1KnkNDQxESEoIrV64gPDwcgYGBZcpcvXoVCxYswNGjR5GamoqbN29i3bp1AIC4uDj897//xdmzZ3Hu3Dn07dsXH330UR23goioYZk4cSLi4+Nx584dbYdCRFTrdCZ5zsnJQUJCAsaNGwcACAgIQEZGRpme45iYGPj5+cHa2hoymQxTpkzBtm3bAAAymQxPnjzB48ePIYTA/fv3IZfL67wtRES67N69e7hx44b0fvfu3WjRogUsLCy0GBURUd3QmTHPGRkZsLGxgYFBScgymQz29vZIT0+Hk5OTVC49PR0ODg7Se4VCgfT0dADAkCFDEB8fD2tra5iYmMDW1haHDx8ud30cq0dEVL7c3FyMGDECjx49gp6eHiwtLfHLL7/wokEieinoTPJcExISEpCUlITr16/D1NQUc+fOxZQpUxAdHV2mbFhYGMLCwqT37KEmIirh4OCAkydPajsMIiKtqNPk+elk9HlMTU2xaNGiMtPt7OyQlZUFlUoFAwMDCCGQnp4Oe3t7tXL29vZIS0uT3iuVSqnM5s2b8frrr0u3WJo4cSIGDBhQ/QYRERER0UulTsc8b9u2DWZmZhW+tm7dWu6yVlZW8Pb2lnqJY2NjIZfL1YZsACVjoePi4pCdnQ0hBNauXYvRo0cDABwdHXHw4EEUFBQAAH755Re4u7vXYouJiIiIqCGp057nvn37YuHChRWWSUlJee68yMhIBAYGYtmyZTA1NUVUVBQAICgoCH5+fvDz84OjoyMWL16MHj16AAD69OmD0NBQAMC0adNw8eJFdOjQAY0aNYK1tTXWrl1bQ60jIiIiooZOJoQQ2g5CF8jlcmRmZlZtoUVmwKLc2gmIiBqcap1ndEhDb9/LRjF3j7ZDqDHKFW9pOwSqIXVxntHKrepOnTqFhw8fAgB++OEHfPDBB2q3PSIiIiIiqo+0kjwHBQXB0NAQKSkp+Pjjj9GoUSO888472giFiIiIiEhjWkme9fX1oa+vj19//RVTp07F8uXLkZOTo41QiIiIiIg0ppXk+cmTJ7h58yZ+/vln9OnTBwBQVFSkjVCIiIiIiDSmleT5/fffh6urK8zMzODt7Y20tDQ0b95cG6EQEREREWlMa2Oe7927h5iYGAAlj9Det2+fNkIhIiIiItJYnSbP586dK3e6vr4+GjduXGEZIiIiIiJtq9PkOTAwsEbKEBERERFpQ50+YfDs2bOwsLB47nwhBJo1a1aHERERERERaa5Ok+e///670jL6+vp1EAkRERERUdXVafLs4OBQl6sjIiIiIqpRWrnbBhERERGRLmLyTERERESkIa0kz7dv39ZoGhERERFRfaKV5HnAgAEaTSMiIiIiqk/q9ILBgoICPH78GEVFRcjLy4MQAgCQm5uLBw8e1GUoRERERERVVqc9z8uXL4e5uTmSkpJgZmYGc3NzmJubw8PDA+PGjavLUIiIiIiIqqxOk+eFCxeiuLgYISEhKC4ull737t3DggUL6jIUIiIiIqIq08qY52+++UYbqyUiIiIieiG8VR0RERERkYaYPBMRERERaYjJMxERERGRhpg8ExERERFpiMkzEREREZGGdCp5TklJQffu3eHi4oIuXbogOTm53HIbNmyAs7Mz2rZti+DgYBQWFkrzzp8/jz59+qBdu3Zo164ddu3aVVfhExEREZGO06nkOTQ0FCEhIbhy5QrCw8MRGBhYpszVq1exYMECHD16FKmpqbh58ybWrVsHAHj48CGGDh2KJUuW4OLFi0hKSsJrr71Wx60gIiIiIl2lM8lzTk4OEhISpCcRBgQEICMjA6mpqWrlYmJi4OfnB2tra8hkMkyZMgXbtm0DAGzduhXdunVDz549AQD6+vqwtLSs24YQERERkc7SmeQ5IyMDNjY2MDAwAADIZDLY29sjPT1drVx6ejocHByk9wqFQipz4cIFGBoaYvDgwfDy8sKECRNw69atumsEEREREek0nUmea4JKpcL+/fsRGRmJM2fOwNbWFlOnTi23bEREBORyufTKz8+v42iJiIiIqL7RmeTZzs4OWVlZUKlUAAAhBNLT02Fvb69Wzt7eHteuXZPeK5VKqYy9vT18fX1ha2sLmUyGcePG4fjx4+WuLywsDJmZmdLL2Ni4llpGRERERLpCZ5JnKysreHt7Izo6GgAQGxsLuVwOJycntXIBAQGIi4tDdnY2hBBYu3YtRo8eDQAYOXIkTp06hfv37wMA9u7diw4dOtRtQ4iIiIhIZxloO4CqiIyMRGBgIJYtWwZTU1NERUUBAIKCguDn5wc/Pz84Ojpi8eLF6NGjBwCgT58+CA0NBVDS8/zRRx+he/fu0NPTg62trXQnDiIiIiKiysiEEELbQegCuVyOzMzMqi20yAxYlFs7ARFRg1Ot84wOaejte9ko5u7Rdgg1RrniLW2HQDWkLs4zOjNsg4iI6ofHjx9j2LBhcHFxQYcOHdC/f/8ytw0lImqomDwTEVGVhYSE4PLlyzh79iyGDh2KoKAgbYdERFQnmDwTEVGVGBkZ4c0334RMJgMAdOvWDUqlUrtBERHVESbPRET0QlavXo2hQ4eWmc775RNRQ6RTd9sgIqL6ZdmyZUhNTcWBAwfKzAsLC0NYWJj0Xi6X12VoRES1gskzERFVy8qVK7Fr1y7s378fTZs21XY4RER1gskzERFVWUREBLZt24b9+/fD3Nxc2+EQEdUZJs9ERFQlmZmZmD17NhwdHeHr6wsAMDQ0xIkTJ7QcGRFR7WPyTEREVSKXy8HnaxHRy4p32yAiIiIi0hCTZyIiIiIiDTF5JiIiIiLSEJNnIiIiIiINMXkmIiIiItIQk2ciIiIiIg0xeSYiIiIi0hCTZyIiIiIiDTF5JiIiIiLSEJNnIiIiIiINMXkmIiIiItIQk2ciIiIiIg0xeSYiIiIi0hCTZyIiIiIiDTF5JiIiIiLSEJNnIiIiIiIN6VTynJKSgu7du8PFxQVdunRBcnJyueU2bNgAZ2dntG3bFsHBwSgsLFSbL4TA66+/DnNz8zqImoiIiIgaCp1KnkNDQxESEoIrV64gPDwcgYGBZcpcvXoVCxYswNGjR5GamoqbN29i3bp1amVWrVqFtm3b1lHURERERNRQ6EzynJOTg4SEBIwbNw4AEBAQgIyMDKSmpqqVi4mJgZ+fH6ytrSGTyTBlyhRs27ZNmp+cnIzdu3dj7ty5dRo/EREREek+nUmeMzIyYGNjAwMDAwCATCaDvb090tPT1cqlp6fDwcFBeq9QKKQyhYWFCA4ORmRkJPT19esueCIiIiJqEHQmea4Jixcvhr+/P9q1a1dp2YiICMjlcumVn59fBxESERERUX2mM8mznZ0dsrKyoFKpAJRc9Jeeng57e3u1cvb29rh27Zr0XqlUSmUOHz6MNWvWQKFQoGfPnrh//z4UCgVu3bpVZn1hYWHIzMyUXsbGxrXYOiIiIiLSBTqTPFtZWcHb2xvR0dEAgNjYWMjlcjg5OamVCwgIQFxcHLKzsyGEwNq1azF69GgAwNGjR3Ht2jUolUr88ccfMDU1hVKphKWlZZ23h4iIiIh0j84kzwAQGRmJyMhIuLi4YMWKFYiKigIABAUFIS4uDgDg6OiIxYsXo0ePHnBycoKlpSVCQ0O1GTZRWYvMtB0BERERVYOBtgOoCldXVxw7dqzM9PXr16u9Dw4ORnBwcIV1KRQK3Lt3rybDIyIiIqIGTqd6nomIiIiItInJMxERERGRhpg8ExERERFpiMkzEREREZGGmDwTEREREWmIyTMRERERkYaYPBMRERERaYjJMxERERGRhpg8ExERERFpiMkzEREREZGGdOrx3ERE9HJRzN2j7RBqjHLFW9oOgYhqAHueiYiIiIg0xOSZiIiqbMaMGVAoFJDJZEhMTNR2OEREdYbJMxERVdnw4cPxxx9/wMHBQduhEBHVKY55JiLdsMjs//83V7txEACgV69e2g6BiEgr2PNMRERERKQhJs9E1DBIPdNm//d/0qqIiAjI5XLplZ+fr+2QiIheGJNnIiKqFWFhYcjMzJRexsbG2g6JiOiFMXkm0lUNsYdV0/Y0tHYTEZHOYPJMRPXP018M6iJRZjJeZaGhoZDL5cjMzMTAgQPh5OSk7ZCIiOoE77ZBRNqxyIx3ztBhkZGR2g6BiEgr2PNMRFSqIQ6FISKiGsXkmYjKYgLJbUBEROVi8lzf1fXYz+fFQNpVH3pEy1t/TcRUH9r2InQ5diIiqjKdSp5TUlLQvXt3uLi4oEuXLkhOTi633IYNG+Ds7Iy2bdsiODgYhYWFAICDBw/Cx8cH7du3h5ubG+bMmYPi4uLaD7y+Jwf1PT7SXF3sy/LW8bIcQy9DG4mIqEI6lTyHhoYiJCQEV65cQXh4OAIDA8uUuXr1KhYsWICjR48iNTUVN2/exLp16wAAzZs3x/bt23HhwgWcPn0af/75JzZv3lzHragDfFhEzXuRW6hxf2i/3dr6UkFERA2OziTPOTk5SEhIwLhx4wAAAQEByMjIQGpqqlq5mJgY+Pn5wdraGjKZDFOmTMG2bdsAAB07doSjoyMAwMjICF5eXlAqlXXaDo1/+q7oj3B5Qzn4h1tdVbdFdXpTa2t7V2e9tXW8NMTjqiaOjZpeBxER6QydSZ4zMjJgY2MDA4OSu+vJZDLY29sjPT1drVx6ejocHByk9wqFokwZAMjOzkZMTAwGDx5cu4E/T10nJQ3tj7m2xoJrmmTXVML1Im2rj/u8po97bSX3DfFLBRERaURnkueadP/+fQwZMgRz5sxB586dyy0TEREBuVwuvfLz82s/sPrwB1nb669MfY+vqurDPiciIiKN6UzybGdnh6ysLKhUKgCAEALp6emwt7dXK2dvb49r165J75VKpVqZvLw8DBo0CEOHDkVYWNhz1xcWFobMzEzpZWxsXMMtokrVdFLJJJWIiIhekM4kz1ZWVvD29kZ0dDQAIDY2FnK5vMwjYQMCAhAXF4fs7GwIIbB27VqMHj0aAJCfn49BgwZh0KBBmD9/fp23gYiIiIh0m84kz0DJ42AjIyPh4uKCFStWICoqCgAQFBSEuLg4AICjoyMWL16MHj16wMnJCZaWlggNDQUArF69GidPnsSuXbvg5eUFLy8vLF26VGvtISIiIiLdYqDtAKrC1dUVx44dKzN9/fr1au+Dg4MRHBxcptzHH3+Mjz/+uNbiIx20yAxYlKvtKIiIiEhH6FTPMxERERGRNjF5phfDh0+QruJxRURE1cDkmRoOJkNERERUy5g8k/Yw2aXaxuOLiIhqGJNnqjlMVIiIiKiBY/JMRDWLX6KIiKgBY/JM1VNbCRIvQCQiIqJ6jMkz1bynk1NNk9T6lMzWp1iIiIioXmHyTES1gz38RETUADF5Js3VVDLEhIqIiIh0FJNnKl9D6TVsKO0gIiKieoHJ88uGySQ9D48NIiKiSjF5JnrZMWEmIiLSGJNnIiIiIiINMXl+mdVljyOHBBAREVEDwOSZiIiIiEhDTJ6JiIiIiDTE5JmIiIiISENMnomIiIiINMTkmYiIiIhIQ0yeiYiIiIg0xOSZiIiIiEhDTJ6JiIiIiDTE5JmIiIiISENMnomIiIiINKRTyXNKSgq6d+8OFxcXdOnSBcnJyeWW27BhA5ydndG2bVsEBwejsLBQo3lERKQZTc/HREQNjU4lz6GhoQgJCcGVK1cQHh6OwMDAMmWuXr2KBQsW4OjRo0hNTcXNmzexbt26SucREZHmNDkfExE1RDqTPOfk5CAhIQHjxo0DAAQEBCAjIwOpqalq5WJiYuDn5wdra2vIZDJMmTIF27Ztq3QeERFpRtPzMRFRQ2Sg7QA0lZGRARsbGxgYlIQsk8lgb2+P9PR0ODk5SeXS09Ph4OAgvVcoFEhPT690HhERaUbT8zER1T3F3D3aDqHGKFe8pe0QyiUTQghtB6GJ06dPY8yYMbh8+bI0zcfHBytWrMDrr78uTXvvvffQunVrzJs3DwBw4cIFDBo0COnp6RXOe1ZERAQiIiKk99nZ2bC2tq5y3Pn5+TA2Nq7ycvUN21F/NIQ2AGxHeW7duoUnT57USF21SdPzcU2dR+tCQzkeGxrul/qrvu6bujiP6kzPs52dHbKysqBSqWBgYAAhBNLT02Fvb69Wzt7eHmlpadJ7pVIplalo3rPCwsIQFhb2wnHL5XJkZma+cD3axnbUHw2hDQDbocs0PR/X1Hm0LryM+1EXcL/UXy/zvtGZMc9WVlbw9vZGdHQ0ACA2NhZyubzMT4QBAQGIi4tDdnY2hBBYu3YtRo8eXek8IiLSjKbnYyKihkhnkmcAiIyMRGRkJFxcXLBixQpERUUBAIKCghAXFwcAcHR0xOLFi9GjRw84OTnB0tISoaGhlc4jIiLNPe98TETU0OnMsA0AcHV1xbFjx8pMX79+vdr74OBgBAcHl1tHRfNqg678ZFkZtqP+aAhtANgOXfe887Gueln3Y33H/VJ/vcz7RmcuGCQiIiIi0jadGrZBRERERKRNTJ6JiIiIiDTE5LmWpKSkoHv37nBxcUGXLl2QnJys7ZAq9fjxYwwbNgwuLi7o0KED+vfvLz0xLCcnB4MGDYKzszPc3d1x5MgRLUermaioKMhkMuzevRuA7rXjyZMnmD59OpydneHh4SE90U3Xjq+9e/fC29sbXl5ecHd3x3fffQeg/u+PGTNmQKFQQCaTITExUZpe0fbXtX2jTSqVCosXL8Yrr7wCd3d3eHl5ISQkBPfu3QMAfPLJJ3B3d0eHDh3wyiuv4MMPPwQAtG/fHr/88otaXQUFBbC0tMRff/1VZj0KhQKurq7w8vKCq6srVqxYUeNtadmyJZRKJQDgzTffVLsHdn2nUChgZWWFwsJCaVp8fDxkMhlmzZpV5fo++OADLFq0qNJygYGB+Pzzz58b09OfuZr0yy+/oE+fPgCAhIQEjBo1qlbWUyovLw/GxsaYPHlyra6ntmzatAlmZmbw8vKSXtOmTavRdQQFBSE+Ph7A84+L0nW3b98e+vr60vtRo0bhX//6F77//vsajalCgmqFr6+viIqKEkIIsXPnTtG5c2ftBqSBR48eiT179oji4mIhhBBr1qwRvXv3FkII8c4774iFCxcKIYQ4efKksLW1FQUFBVqKVDNXr14Vr776qujWrZv48ccfhRC6145Zs2aJ6dOnS/skKytLCKFbx1dxcbFo3ry5OHv2rBCiZL8YGhqK+/fv1/v9cfjwYZGRkSEcHBzEmTNnpOkVbX9d2jfaNmHCBDF48GDxzz//CCFKjpUffvhBpKWliZ07d4pu3bqJhw8fCiGEKCwsFImJiUIIIVauXCn8/f3V6tq5c6fw8vIqdz1P77/MzExhamoqTpw4UaNtadGihbh69WqN1llXHBwcRKdOnURMTIw0bezYsaJz585i5syZVa5v9uzZ0ue6IhMnThSrVq16bkxPf+Zq0s8//yz9basL3377rejVq5cwNzcXeXl5NVZvUVGRKCoqqrH6nicqKkoMHTq01tdTqqLjQoiSvyFmZmZ1Fk952PNcC3JycpCQkCD1EgYEBCAjI0Pqxa2vjIyM8Oabb0ImkwEAunXrJvWk/PDDD5gyZQoAoEuXLmjdujUOHz6srVArVVxcjKCgIKxZswaGhobSdF1qx4MHD7BhwwYsXbpU2ifW1tY6eXzJZDKpN/H+/fto0aIFDA0N6/3+6NWrF+Ryudq0ira/Lu4bbUlNTcXOnTsRFRWF5s2bAyg5TkaMGAFHR0dkZmbCwsICRkZGAAADAwN06NABADB+/Hj8/vvvuH37tlTfxo0bNerZs7W1xSuvvIJr164BKHnq4ciRI+Hj4wMPDw/Mnz9fKvvBBx+gS5cu8PLyQq9evdR6k+Pi4tCuXTt4enpizpw5aut4ute0T58++OCDD/Daa6+hbdu20vEOAFlZWRgwYADat2+PAQMGYPTo0Rr12NaGd955Bxs3bgQA5Obm4vjx4xg0aJA0v6ioCB9++CHc3d3h7u6O9957DwUFBQBK2jFw4EC0b98e/fr1U3twRmFhIebOnQsfHx94eXlh5MiRuHv3brXj/P333+Ht7Q1PT0/07t0bFy5cAFCyH319fdGpUye4ublh+vTpKC4ulmJ499134ezsDB8fH6mHEwAOHToELy8vACUPTjM3N8fChQvRqVMnODk5Ye/evVLZn376Ce3atUOHDh0QHh6u9mtDRTZs2IDw8HD06tULO3bsAAAsXboU06dPl8rk5+fDwsICt27dAgCsXLkSPj4+8Pb2xqBBg6TjddGiRQgICMDAgQPh7u6OrKysCo/TimJOSUnBW2+9hS5dusDT0xNffvllFfdGSTwjR47EkCFD4OLigsGDByMpKQkDBw6Ei4sL3n77bWk/bN26FV27dkXHjh3RoUMH/Pzzz1I9ffr0kX4hro6ne6urElNeXh6Cg4Ph4+MDT09PhISESMd1RZg814KMjAzY2NjAwKDkToAymQz29vblPga8Plu9ejWGDh2KO3fuoLCwUO2xugqFol63JyIiAj169ECnTp2kabrWjrS0NFhYWGDZsmXo3LkzXnvtNRw4cEDnji+ZTIYdO3bA398fDg4O6NmzJ7777jvk5eXp1P4oVdH217V9o01//fUXnJ2d0bJly3Lnjx49GlevXoWjoyMmTJiAjRs34tGjRwBKHtIycOBA6SEt169fx5EjRzB27NhK13vp0iXcuXNH+tl+4sSJmDZtGk6ePIkzZ84gISEBO3fuBACEh4fj1KlTSExMxLvvvouZM2cCKPkC9c477yA2Nhbnzp2Dk5MT7ty589x1pqWlIT4+HklJSfj999+lW/zNmDEDr776Ki5cuIDNmzfj0KFDGm272tCjRw8olUrcuHED27Ztw4gRI6Cvry/NX7duHU6dOoXTp08jMTERaWlpWLVqFYCSdvj4+ODChQv47rvvcODAAWm5Tz/9FM2aNcPJkyeRmJhY5gtKVeTk5GDMmDH47rvvcO7cOYSEhGD48OEQQsDc3Bw///wzTp8+jXPnzkGpVOKHH36QYr98+TKSk5Pxxx9/lDu0p1Rubi48PT1x+vRpfPnll3j//feldU+aNAk//vgjzp49i1deeaXCfV7qwoULyMjIwMCBAzF58mRs2LABADBhwgT88MMP0mOkd+7cCV9fX1haWmLr1q24fPkyjh07hr/++gtjx47Fu+++K9V57NgxbN68GRcuXICtrW2Fx+nzYi4qKsLbb7+Nzz77DKdOncLx48elfVye+Ph4tWEbpfseKBn6snnzZly+fBl5eXkICgpCTEwMLly4gIsXL+LXX38FAAwcOBDHjx/HmTNn8NNPPyE4OLjWHqOtaUyzZ8/Ga6+9hpMnT+Ls2bMoLi7G6tWrK61fp+7zTHVn2bJlSE1NxYEDB6Q/WLoiKSkJsbGx9W78bFWpVCpcu3YN7du3x4oVK3DmzBn0798fe/bs0XZoVaJSqbBkyRLs2rULvXr1wqlTp+Dn51dr4xmpYbC2tsb58+dx4sQJ/Pe//8XXX3+NNWvW4MSJE2jcuDEmT56MefPmYdasWfjuu+/g5+cn9WCXZ9SoUdDT08Ply5exatUqWFpa4sGDBzhw4ABu3rwplcvPz5d67vbt24c1a9YgLy8PxcXF+OeffwAAx48fh6enJ9q3bw8AmDx5Mt57770K121gYAADAwN4eXkhLS0Nr776Kg4cOICVK1dK7R08ePALb7cXMX78eGzatAm7d+/G999/rzaGdP/+/QgMDJR+yQsODsZXX32F8PBwtXbY2trCz89PWm737t3Izc1FbGwsgJKx6QqFolrxnThxAh4eHvDw8AAAjB07FtOmTcP169dhYWGB8PBw/PHHHxBCICcnB+7u7hg9ejQOHDiACRMmoHHjxgCASZMmSUnss4yMjODv7w8AePXVV5GWlgbg//b5K6+8AqDkS9fTvyI8z4YNGzBhwgTo6+vjzTffRGhoKC5evIh27dqhY8eOiIuLw4gRI7Bp0yZpTP/u3btx6tQpqfOnqKhIrc4333wTrVq1kt5XdpyWF3Ppl4mnn7Kcl5eHCxcuoEuXLmXa4evr+9ye4QEDBkifPW9vbxgaGsLExAQA0LFjR6SkpAAArl69irFjxyIzMxMGBgb4559/cPXqVSm+mqRpTLt378axY8cQEREBAHj06JHal8bnYfJcC+zs7JCVlQWVSgUDAwMIIZCeng57e3tth6aRlStXYteuXdi/fz+aNm2Kpk2bwsDAANnZ2VIvoVKprLftOXr0KJRKJZydnQGU/JwXEhKCxYsX61Q77O3toaenJ/WmdezYEW3atMG1a9d06vhKTEzEjRs30KtXLwAlwzPkcjnOnTunU/ujVEWfb1NTU53aN9rk7e2NlJQU3LlzBy1atCi3jL6+Prp3747u3btjxowZaNWqFZKSkuDt7Y2BAwciJCQECQkJ2LRpE7755psK17djxw54eXlh//79GDJkCF5//XW0adMGQEmSUTo8pFR6ejqmT5+OU6dOoW3btjh37px0DD+rdFjV8zxdt76+PlQqVbXqqW0TJkyAt7c3XFxcpPPn81QU69PzhBBYs2YNBgwYUGNxliciIgI5OTk4ceIEjIyMEBYWhsePH1ca37MMDQ2l+fr6+mUS16ooLCzEli1b0KhRI2zduhUA8PDhQ2zYsAErV67EpEmTEBUVhU6dOiE1NVUaJiOEwLx58xASElJuvcbGxtL/q3KcPk0IAQsLixrpxHj2+H7e8T569GisWLECw4cPBwBYWFg8dx/VVUxCCMTGxsLFxaVK9XPYRi2wsrKCt7e39JNibGws5HI5nJyctBxZ5SIiIrBt2zbs27cP5ubm0vQRI0Zg7dq1AIBTp07h+vXr6N27t5airNjUqVORlZUFpVIJpVKJbt26Yd26dZg6dapOtaNly5bo27cvfv/9dwAl39qvXr2KHj166NTxVZpsXrx4EUDJWNe0tDS4urrq1P4oVdHnW5c/+3XNyckJAQEBmDx5sjQevvQP2d9//42EhASp1w8oGW5RWFgIOzs7ACV/AAMDAzF16lSoVCq8/vrrGq23X79+mDp1KubPnw9jY2P4+vqq3X3jxo0byMzMRG5uLho1agQbGxsIIdTGg7766qs4d+4cLl26BKBkvLUm4ySf9frrr2PTpk0AgJs3b5a5g0hda926NZYvX47//Oc/Zeb169cPmzdvRkFBAVQqFdavXy8lxP369ZPGS2dlZSEuLk5abtiwYVi1ahUePnwIoCR5rO4daLp164bz588jKSkJALB9+3bY2trC1tYWd+/ehbW1NYyMjJCdnS0NvSmNLzo6GoWFhSgoKKjWo+S7deuGc+fOSb9KREdHV7rP4+Li4OjoiOvXr0t/j44fP44tW7agsLAQw4YNw6lTp7B8+XKMGzdOGu41bNgwrF27VupBLiwsxJkzZ8pdR0XHaUUxu7q6wtTUVG1bpKamSuusDXfv3pW+sEZHR7/Q2PeaMmzYMPznP/+Rkum7d+9qdI0Ke55rSWRkJAIDA7Fs2bIyB2h9lZmZidmzZ8PR0RG+vr4ASr6FnzhxAv/5z38wfvx4ODs7o3HjxoiOjkajRo20HHHV6Vo71q5di8mTJyM8PBx6enqIjIyEra2tTh1frVq1wrp16zBy5Ejo6emhuLgYX375Jezt7ev9/ggNDcWePXuQnZ2NgQMHwsTEBKmpqRVuf13aN9q2ceNGLFmyBF27doWBgQGKi4vRq1cv9O3bFykpKZg+fTru3buHJk2aQF9fH1u3boWlpaW0/KRJk7Bs2TIsXry4Sr22CxYsgJOTE06fPo3vv/8eYWFhcHd3h0wmQ7NmzRAZGYkOHTpg9OjRcHNzQ4sWLTBs2DBpeUtLS2zcuBH/8z//g8aNG2PQoEHP7T2vyOrVqzFx4kS0b98erVu3RteuXdU6LbThnXfeKXd6SEgI0tLS4O3tDaDkAq/S29itXr0agYGBaN++PWxtbdW+yISHh+PJkyfo2rWrtI/Cw8Ph5uZWaSwDBw5UOx8cP34c33//PSZMmACVSoXmzZtj586dkMlkmDlzJoYPHw43Nze0bt0a/fr1k5YLDg5GUlIS2rdvj+bNm+O1117D6dOnq7RdrKyssH79egwbNgyGhobo378/jI2NK9xfGzZsKDMOv127drC1tcXPP/8Mf39/jBw5El9//bXUuQCUDEe5c+eO9HdYpVJh0qRJ6NixY5l1eHh4PPc4rShmAwMD/PLLL5g1axZWrVqFoqIitGzZUuohf1bpmOdSrq6u0sWPmlq9ejWGDx8Oc3NzvP766/XiF7lVq1Zh7ty58PLygp6eHgwMDPD//t//q7TDg4/nJiIi0oJHjx6hUaNGMDAwwJ07d9CtWzdER0eja9eu2g6NypGXlyeNm929ezfmzZunlvTWR7oYsy5gzzMREZEWpKSkYMKECRBCoKCgAO+++y4T53pszZo12LFjB4qKimBqalq3D+WoJl2MWRew55mIiIiISEO8YJCIiIiISENMnomIiIiINMTkmYiIiIhIQ0yeiSqhUCjg6uqq9mjS8+fP10jdCQkJGDVqFICSB4Ro+zZVREREVDFeMEhUCYVCgd27d6vd47I2KJVKeHl5SQ+MICIiovqHPc9E1SSTybB06VJ07dpVSrCXL1+Ozp07w9nZGYcOHQJQcoP7gQMHonPnznBzc8OYMWPw4MEDAMChQ4dqPSknIiKimsPkmUgDo0aNUhu28ejRIwCAsbExTpw4gQ0bNmDcuHGwsbFBQkICli1bhg8//BAApCejJSQkICkpCWZmZlizZo02m0NERETVxIekEGlgx44d5fYQl45X7ty5Mx48eIDRo0cDAHx8fJCSkgIAEEJg1apV2LNnD1QqFXJzc9G9e/c6i52IiIhqDnueiV6AkZERgJLe5Wffq1QqAMDWrVtx8OBBHD58GOfPn8cHH3yAx48faydgIiIieiFMnolq2d27d9GyZUuYmpoiLy8PmzZt0nZIREREVE0ctkGkgVGjRqFJkybS+1WrVmm87IQJE/DTTz/B1dUVlpaWeO2113Dt2rXaCJOIiIhqGW9VR0RERESkIQ7bICIiIiLSEJNnIiIiIiINMXkmIiIiItIQk2ciIiIiIg0xeSYiIiIi0hCTZyIiIiIiDTF5JiIiIiLSEJNnIiIiIiINMXkmIiIiItLQ/wdrS7wvCjAGAAAAAABJRU5ErkJggg==",
-      "text/plain": [
-       "<Figure size 800x320 with 2 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# display timestamps\n",
     "\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ dependencies = [
   "torch",
   "pandas",
   "jupyter",
-  "matplotlib"
+  "matplotlib",
+  "langid",
+  "langdetect"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,8 @@ dependencies = [
   "jupyter",
   "matplotlib",
   "langid",
-  "langdetect"
+  "langdetect",
+  "intervaltree"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ es_core_news_md @ https://github.com/explosion/spacy-models/releases/download/es
 transformers
 pandas
 jupyter
+langid
+langdetect

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandas
 jupyter
 langid
 langdetect
+intervaltree


### PR DESCRIPTION
Implemented language detection feature in the file utils.py (issue #45)
* Class LangDetector contains all necessary methods for detecting language
* There are two libraries used for this feature: `langdetect` and `langid`
    * The detected language depends on the length of a text and how many languages utilized in the text. In general both libraries yield similar results, but `langdetect` seems having more correct detections.
    * However,
        * The results of `langdetect` is non-deterministic, one should use method `determine_langdetect` to enforce consistent results for `langdetect`
        * One can set language constraints with `langid` (e.g. detect if a text in fr or es, not other languages)
            * Use method `constrain_langid` for this feature
        * `langid` handles quite well special cases (e.g. empty text, only punctuation, etc.)
* To detect language of a whole text, use the wrapper `get_detections` (special inputs are handled)
    * Methods such as `contains_only_punctuations`, `contains_only_numbers`, `contains_only_emails` are used to handle special inputs (mainly for `langdetect` library)
* One can also use `detect_with_langid` or `detect_with_langdetect` for a whole text (special inputs will raise exceptions)
* To detect language for each sentence in a document, use `detect_lang_sentences`
    * The result is an IntervalTree marking line numbers and their corresponding detected languages (e.g. `IntervalTree([Interval(0, 2, 'fr')])`)

Other changes:
* `check_dir` and `make_dir` functions from `parse.py` are now moved to `utils.py`
* A sample code for activating language detection feature for each sentence in an email is added at the end of `parse.py`