### PR TITLE
Data validation

### DIFF
--- a/mailcom/inout.py
+++ b/mailcom/inout.py
@@ -189,14 +189,10 @@ class InoutHandler:
         self.email_list = [
             {
                 **{
-                    field: (
-                        row[col] if col in df.columns else unmatched_keyword
-                    )  # TODO discuss
+                    field: (row[col] if col in df.columns else unmatched_keyword)
                     for col, field in zip(common_cols, common_fields)
                 },
-                **{
-                    col: row[col] for col in remaining_cols if col in df.columns
-                },  # TODO discuss
+                **{col: row[col] for col in remaining_cols if col in df.columns},
                 **{field: None for field in remaining_fields},
             }
             for _, row in df.iterrows()

--- a/mailcom/inout.py
+++ b/mailcom/inout.py
@@ -7,12 +7,17 @@ import pandas as pd
 
 
 class InoutHandler:
-    def __init__(
-        self,
-        init_data_fields: list = ["content", "date", "attachment", "attachement type"],
-    ):
+    def __init__(self, init_data_fields: list = None):
         self.email_list = []
-        self.init_data_fields = init_data_fields
+        if not init_data_fields:
+            self.init_data_fields = [
+                "content",
+                "date",
+                "attachment",
+                "attachement type",
+            ]
+        else:
+            self.init_data_fields = init_data_fields
 
     def list_of_files(self, directory_name: str, file_types: list = [".eml", ".html"]):
         """Method to create a list of Path objects (files) that are present

--- a/mailcom/inout.py
+++ b/mailcom/inout.py
@@ -187,8 +187,6 @@ class InoutHandler:
         except OSError:
             raise OSError("File {} does not exist".format(infile))
         except KeyError:
-            raise KeyError(
-                "Error while getting columns from the file".format(col_names)
-            )
+            raise KeyError("Column {} does not exist in the file".format(col))
         except pd.errors.EmptyDataError:
             self.email_list = []

--- a/mailcom/main.py
+++ b/mailcom/main.py
@@ -6,6 +6,8 @@ from mailcom.time_detector import TimeDetector
 from mailcom.parse import Pseudonymize
 import json
 from collections.abc import Iterator
+from importlib import resources
+import jsonschema
 
 
 def get_input_handler(
@@ -37,6 +39,25 @@ def get_input_handler(
         inout_handler.list_of_files(in_path, file_types)
         inout_handler.process_emails()
     return inout_handler
+
+
+def is_valid_settings(workflow_setting: dict) -> bool:
+    """Check if the workflow settings are valid.
+    Args:
+        workflow_setting (dict): The workflow settings.
+
+    Returns:
+        bool: True if the settings are valid, False otherwise.
+    """
+    pkg = resources.files("mailcom")
+    setting_schema_path = Path(pkg / "setting_schema.json")
+    setting_schema = json.load(open(setting_schema_path, "r", encoding="utf-8"))
+
+    try:
+        jsonschema.validate(instance=workflow_setting, schema=setting_schema)
+        return True
+    except jsonschema.ValidationError:
+        return False
 
 
 def get_workflow_settings(workflow_settings: str) -> dict:

--- a/mailcom/main.py
+++ b/mailcom/main.py
@@ -13,7 +13,8 @@ import jsonschema
 def get_input_handler(
     in_path: str,
     in_type: str = "dir",
-    col_name: str = "message",
+    col_names: list = ["message"],
+    init_data_fields: list = ["content", "date", "attachment", "attachement type"],
     file_types: list = [".eml", ".html"],
 ) -> InoutHandler:
     """Get input handler for a file or directory.
@@ -22,19 +23,20 @@ def get_input_handler(
         in_path (str): The path to the input data.
         in_type (str, optional): The type of input data. Defaults to "dir".
             Possible values are ["dir", "csv"].
-        col_name (str, optional): The name of the column containing
-            the main content in csv file.
-            Defaults to "message".
+        col_names (list, optional): The list of column names that
+            map the init_data_fields.
         file_types (list, optional): The list of file types
             to be processed in the directory.
             Defaults to [".eml", ".html"].
+        init_data_fields (list, optional): The list of fields
+            should be present in the data dict.
 
     Returns:
         InoutHandler: The input handler object.
     """
-    inout_handler = InoutHandler()
+    inout_handler = InoutHandler(init_data_fields)
     if in_type == "csv":
-        inout_handler.load_csv(in_path, col_name)
+        inout_handler.load_csv(in_path, col_names)
     else:
         inout_handler.list_of_files(in_path, file_types)
         inout_handler.process_emails()
@@ -162,6 +164,10 @@ def write_output_data(inout_hl: InoutHandler, out_path: str):
     """
     if not out_path:
         raise ValueError("No output path specified")
+
+    # check if the output file is not empty
+    if Path(out_path).is_file() and Path(out_path).stat().st_size > 0:
+        raise ValueError("Output file is not empty")
 
     file_type = Path(out_path).suffix[1:]
 

--- a/mailcom/main.py
+++ b/mailcom/main.py
@@ -123,6 +123,10 @@ def process_data(email_list: Iterator[list[dict]], workflow_settings: dict):
         time_detector = TimeDetector(parsing_type, spacy_loader)
 
     for email in email_list:
+        # skip if email content is empty or not present
+        if not email.get("content"):
+            continue
+
         email_content, _ = utils.clean_up_content(email["content"])
         email["cleaned_content"] = email_content
 

--- a/mailcom/main.py
+++ b/mailcom/main.py
@@ -77,18 +77,17 @@ def process_data(email_list: Iterator[list[dict]], workflow_settings: dict):
         workflow_settings (dict): The workflow settings.
     """
     # get workflow settings
-    settings = workflow_settings.get("pseudonymize", {})
-    lang = settings.get("default_lang", "")
+    lang = workflow_settings.get("default_lang", "")
     detect_lang = False if lang else True
-    detect_datetime = settings.get("datetime_detection", True)
-    pseudo_emailaddresses = settings.get("pseudo_emailaddresses", True)
-    pseudo_ne = settings.get("pseudo_ne", True)
-    pseudo_numbers = settings.get("pseudo_numbers", True)
-    pseudo_first_names = settings.get("pseudo_first_names", {})
-    lang_lib = settings.get("lang_detection").get("lang_lib", "langid")
-    lang_pipeline = settings.get("lang_detection").get("pipeline", None)
-    spacy_model = settings.get("spacy_model", "default")
-    ner_pipeline = settings.get("ner_pipeline", None)
+    detect_datetime = workflow_settings.get("datetime_detection", True)
+    pseudo_emailaddresses = workflow_settings.get("pseudo_emailaddresses", True)
+    pseudo_ne = workflow_settings.get("pseudo_ne", True)
+    pseudo_numbers = workflow_settings.get("pseudo_numbers", True)
+    pseudo_first_names = workflow_settings.get("pseudo_first_names", {})
+    lang_lib = workflow_settings.get("lang_detection_lib", "langid")
+    lang_pipeline = workflow_settings.get("lang_pipeline", None)
+    spacy_model = workflow_settings.get("spacy_model", "default")
+    ner_pipeline = workflow_settings.get("ner_pipeline", None)
 
     # init necessary objects
     spacy_loader = utils.SpacyLoader()
@@ -97,7 +96,7 @@ def process_data(email_list: Iterator[list[dict]], workflow_settings: dict):
     if detect_lang:
         lang_detector = LangDetector(trans_loader)
     if detect_datetime:
-        parsing_type = settings.get("time_parsing", "strict")
+        parsing_type = workflow_settings.get("time_parsing", "strict")
         time_detector = TimeDetector(parsing_type, spacy_loader)
 
     for email in email_list:

--- a/mailcom/setting_schema.json
+++ b/mailcom/setting_schema.json
@@ -1,0 +1,149 @@
+{
+    "$defs": {
+        "pipelineStructure": {
+            "type": ["null", "object"],
+            "properties": {
+                "task": {
+                    "type": "string",
+                    "title": "Pipneline Task",
+                    "description": "The task to perform the pipeline."
+                },
+                "model": {
+                    "type": "string",
+                    "title": "Pipeline Model",
+                    "description": "The model to use for the pipeline."
+                },
+                "revision": {
+                    "type": "string",
+                    "title": "Pipeline Model Revision",
+                    "description": "The revision of the pipeline model."
+                },
+                "aggregation_strategy": {
+                    "type": "string",
+                    "title": "Pipeline Aggregation Strategy",
+                    "description": "The aggregation strategy for the pipeline.",
+                    "default": "simple"
+                },
+                "required": [
+                    "task",
+                    "model"
+                ]
+            }
+        }
+    },
+    "type": "object",
+    "properties": {
+        "default_lang": {
+            "type": "string",
+            "title": "Default Language",
+            "description": "The default language for the text.",
+            "default": "fr"
+        },
+        "datetime_detection": {
+            "type": "boolean",
+            "title": "Datetime Detection",
+            "description": "Enable or disable datetime detection.",
+            "default": true
+        },
+        "time_parsing": {
+            "type": "string",
+            "title": "Time Parsing Type",
+            "description": "Type for parsing date time in the text.",
+            "default": "strict",
+            "emum": [
+                "strict",
+                "non-strict"
+            ]
+        },
+        "pseudo_emailaddresses": {
+            "type": "boolean",
+            "title": "Pseudo Email Addresses",
+            "description": "Enable or disable pseudo email addresses.",
+            "default": true
+        },
+        "pseudo_ne": {
+            "type": "boolean",
+            "title": "Pseudo Named Entities",
+            "description": "Enable or disable pseudo named entities.",
+            "default": true
+        },
+        "pseudo_numbers": {
+            "type": "boolean",
+            "title": "Pseudo Numbers",
+            "description": "Enable or disable pseudo numbers.",
+            "default": true
+        },
+        "pseudo_first_names": {
+            "type": "object",
+            "properties": {
+                "lang": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            },
+            "title": "List of Pseudo First Names",
+            "description": "Define pseudo first names for each language.",
+            "default": {
+                "es": [
+                    "José",
+                    "Angel",
+                    "Alex",
+                    "Ariel",
+                    "Cruz",
+                    "Fran",
+                    "Arlo",
+                    "Adri",
+                    "Marce",
+                    "Mati"
+                ],
+                "fr": [
+                    "Claude",
+                    "Dominique",
+                    "Claude",
+                    "Camille",
+                    "Charlie",
+                    "Florence",
+                    "Francis",
+                    "Maxime",
+                    "Remy",
+                    "Cécile"
+                ],
+                "de": ["Mika"]
+            }
+        },
+        "lang_detection_lib": {
+            "type": "string",
+            "title": "Language Detection Library",
+            "description": "The library to use for language detection.",
+            "default": "langid",
+            "enum": [
+                "langid",
+                "langdetect",
+                "trans"
+            ]
+        },
+        "lang_pipeline": {
+            "$ref": "#/$defs/pipelineStructure",
+            "title": "Language Detection Pipeline",
+            "description": "The pipeline to use for language detection.",
+            "default": null
+        },
+        "spacy_model": {
+            "type": "string",
+            "title": "Spacy Model",
+            "description": "The Spacy model for time detection and sentence splitting.",
+            "default": "default"
+        },
+        "ner_pipeline": {
+            "$ref": "#/$defs/pipelineStructure",
+            "title": "NER Pipeline",
+            "description": "The pipeline to use for NER.",
+            "default": null
+        }
+    }
+}

--- a/mailcom/setting_schema.json
+++ b/mailcom/setting_schema.json
@@ -1,34 +1,36 @@
 {
     "$defs": {
         "pipelineStructure": {
-            "type": ["null", "object"],
-            "properties": {
-                "task": {
-                    "type": "string",
-                    "title": "Pipneline Task",
-                    "description": "The task to perform the pipeline."
-                },
-                "model": {
-                    "type": "string",
-                    "title": "Pipeline Model",
-                    "description": "The model to use for the pipeline."
-                },
-                "revision": {
-                    "type": "string",
-                    "title": "Pipeline Model Revision",
-                    "description": "The revision of the pipeline model."
-                },
-                "aggregation_strategy": {
-                    "type": "string",
-                    "title": "Pipeline Aggregation Strategy",
-                    "description": "The aggregation strategy for the pipeline.",
-                    "default": "simple"
-                },
-                "required": [
-                    "task",
-                    "model"
-                ]
-            }
+            "oneOf": [
+                {"type": "null"},
+                {
+                    "type": "object",
+                    "properties": {
+                        "task": {
+                            "type": "string",
+                            "title": "Pipneline Task",
+                            "description": "The task to perform the pipeline."
+                        },
+                        "model": {
+                            "type": "string",
+                            "title": "Pipeline Model",
+                            "description": "The model to use for the pipeline."
+                        },
+                        "revision": {
+                            "type": "string",
+                            "title": "Pipeline Model Revision",
+                            "description": "The revision of the pipeline model."
+                        },
+                        "aggregation_strategy": {
+                            "type": "string",
+                            "title": "Pipeline Aggregation Strategy",
+                            "description": "The aggregation strategy for the pipeline.",
+                            "default": "simple"
+                        }
+                    },
+                    "required": ["task", "model"]
+                }
+            ]
         }
     },
     "type": "object",
@@ -50,7 +52,7 @@
             "title": "Time Parsing Type",
             "description": "Type for parsing date time in the text.",
             "default": "strict",
-            "emum": [
+            "enum": [
                 "strict",
                 "non-strict"
             ]
@@ -86,6 +88,7 @@
                     }
                 }
             },
+            "minProperties": 1,
             "title": "List of Pseudo First Names",
             "description": "Define pseudo first names for each language.",
             "default": {
@@ -145,5 +148,6 @@
             "description": "The pipeline to use for NER.",
             "default": null
         }
-    }
+    },
+    "additionalProperties": false
 }

--- a/mailcom/setting_schema.json
+++ b/mailcom/setting_schema.json
@@ -35,6 +35,12 @@
     },
     "type": "object",
     "properties": {
+        "csv_col_unmatched_keyword": {
+            "type": "string",
+            "title": "CSV Column Unmatched",
+            "description": "Keyword to makr unmatched columns while reading csv file.",
+            "default": "unmatched"
+        },
         "default_lang": {
             "type": "string",
             "title": "Default Language",

--- a/mailcom/settings.json
+++ b/mailcom/settings.json
@@ -1,43 +1,39 @@
 {
-    "pseudonymize": {
-        "default_lang": "fr",
-        "datetime_detection": true,
-        "time_parsing": "strict",
-        "pseudo_emailaddresses": true,
-        "pseudo_ne": true,
-        "pseudo_numbers": true,
-        "pseudo_first_names": {
-            "es": [
-                "José",
-                "Angel",
-                "Alex",
-                "Ariel",
-                "Cruz",
-                "Fran",
-                "Arlo",
-                "Adri",
-                "Marce",
-                "Mati"
-            ],
-            "fr": [
-                "Claude",
-                "Dominique",
-                "Claude",
-                "Camille",
-                "Charlie",
-                "Florence",
-                "Francis",
-                "Maxime",
-                "Remy",
-                "Cécile"
-            ],
-            "de": ["Mika"]
-        },
-        "lang_detection": {
-            "lang_lib": "langid",
-            "lang_pipeline": null
-        },
-        "spacy_model": "default",
-        "ner_pipeline": null
-    }
+    "default_lang": "fr",
+    "datetime_detection": true,
+    "time_parsing": "strict",
+    "pseudo_emailaddresses": true,
+    "pseudo_ne": true,
+    "pseudo_numbers": true,
+    "pseudo_first_names": {
+        "es": [
+            "José",
+            "Angel",
+            "Alex",
+            "Ariel",
+            "Cruz",
+            "Fran",
+            "Arlo",
+            "Adri",
+            "Marce",
+            "Mati"
+        ],
+        "fr": [
+            "Claude",
+            "Dominique",
+            "Claude",
+            "Camille",
+            "Charlie",
+            "Florence",
+            "Francis",
+            "Maxime",
+            "Remy",
+            "Cécile"
+        ],
+        "de": ["Mika"]
+    },
+    "lang_detection_lib": "langid",
+    "lang_pipeline": null,
+    "spacy_model": "default",
+    "ner_pipeline": null
 }

--- a/mailcom/settings.json
+++ b/mailcom/settings.json
@@ -1,4 +1,5 @@
 {
+    "csv_col_unmatched_keyword": "unmatched",
     "default_lang": "fr",
     "datetime_detection": true,
     "time_parsing": "strict",

--- a/mailcom/test/settings_for_testing.json
+++ b/mailcom/test/settings_for_testing.json
@@ -1,4 +1,5 @@
 {
+    "csv_col_unmatched_keyword": "unmatched",
     "default_lang": "",
     "datetime_detection": true,
     "time_parsing": "strict",

--- a/mailcom/test/settings_for_testing.json
+++ b/mailcom/test/settings_for_testing.json
@@ -1,43 +1,39 @@
 {
-    "pseudonymize": {
-        "default_lang": "",
-        "datetime_detection": true,
-        "time_parsing": "strict",
-        "pseudo_emailaddresses": true,
-        "pseudo_ne": true,
-        "pseudo_numbers": true,
-        "pseudo_first_names": {
-            "es": [
-                "José",
-                "Angel",
-                "Alex",
-                "Ariel",
-                "Cruz",
-                "Fran",
-                "Arlo",
-                "Adri",
-                "Marce",
-                "Mati"
-            ],
-            "fr": [
-                "Claude",
-                "Dominique",
-                "Claude",
-                "Camille",
-                "Charlie",
-                "Florence",
-                "Francis",
-                "Maxime",
-                "Remy",
-                "Cécile"
-            ],
-            "de": ["Mika"]
-        },
-        "lang_detection": {
-            "lang_lib": "langid",
-            "lang_pipeline": null
-        },
-        "spacy_model": "default",
-        "ner_pipeline": null
-    }
+    "default_lang": "",
+    "datetime_detection": true,
+    "time_parsing": "strict",
+    "pseudo_emailaddresses": true,
+    "pseudo_ne": true,
+    "pseudo_numbers": true,
+    "pseudo_first_names": {
+        "es": [
+            "José",
+            "Angel",
+            "Alex",
+            "Ariel",
+            "Cruz",
+            "Fran",
+            "Arlo",
+            "Adri",
+            "Marce",
+            "Mati"
+        ],
+        "fr": [
+            "Claude",
+            "Dominique",
+            "Claude",
+            "Camille",
+            "Charlie",
+            "Florence",
+            "Francis",
+            "Maxime",
+            "Remy",
+            "Cécile"
+        ],
+        "de": ["Mika"]
+    },
+    "lang_detection_lib": "langid",
+    "lang_pipeline": null,
+    "spacy_model": "default",
+    "ner_pipeline": null
 }

--- a/mailcom/test/test_inout.py
+++ b/mailcom/test/test_inout.py
@@ -272,7 +272,7 @@ def test_load_csv_invalid_col(get_instant, tmp_path):
         )
 
     # Test with a non-existing column name
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match="Column nonexisting does not exist in the file"):
         col_name = "nonexisting"
         get_instant.load_csv(infile, [col_name])
 

--- a/mailcom/test/test_inout.py
+++ b/mailcom/test/test_inout.py
@@ -272,9 +272,13 @@ def test_load_csv_invalid_col(get_instant, tmp_path):
         )
 
     # Test with a non-existing column name
-    with pytest.raises(KeyError, match="Column nonexisting does not exist in the file"):
-        col_name = "nonexisting"
-        get_instant.load_csv(infile, [col_name])
+    get_instant.load_csv(infile, ["nonexisting"], unmatched_keyword="unmatched")
+    emails = get_instant.get_email_list()
+    email = next(emails)
+    assert email["content"] == "unmatched"
+    assert email["date"] is None
+    assert email["attachment"] is None
+    assert email["attachement type"] is None
 
 
 def test_load_csv_invalid_file(get_instant):

--- a/mailcom/test/test_main.py
+++ b/mailcom/test/test_main.py
@@ -276,6 +276,17 @@ def test_process_data_no_numbers(get_data, get_settings, get_inout_hl):
     )
 
 
+def test_process_data_empty_email(get_data, get_settings, get_inout_hl):
+    get_inout_hl.email_list = get_data
+    get_inout_hl.email_list.append({"no-content": "test"})
+    main.process_data(get_inout_hl.get_email_list(), get_settings)
+    emails = get_inout_hl.get_email_list()
+    next(emails)
+    next(emails)
+    email_3 = next(emails)
+    assert "pseudo_content" not in email_3
+
+
 def test_write_output_data_csv(get_data, tmp_path, get_inout_hl):
     outpath = tmp_path / "test_output.csv"
     get_inout_hl.email_list = get_data

--- a/mailcom/test/test_main.py
+++ b/mailcom/test/test_main.py
@@ -307,15 +307,30 @@ def test_write_output_data_xml(get_data, tmp_path, get_inout_hl):
         assert lines[0].count('<email type="dict">') == 2
 
 
-def test_write_output_data_invalid(get_data, tmp_path, get_inout_hl):
+def test_write_output_data_invalid(get_data, tmp_path, get_inout_hl, tmpdir):
+    # invalid file type
     outpath = tmp_path / "test_output.txt"
     with pytest.raises(ValueError):
         main.write_output_data(get_inout_hl, outpath)
 
+    # empty data to write
     outpath = tmp_path / "test_output.csv"
     with pytest.raises(ValueError):
         main.write_output_data(get_inout_hl, outpath)
 
+    # empty path
     get_inout_hl.email_list = get_data
     with pytest.raises(ValueError):
         main.write_output_data(get_inout_hl, "")
+
+    # invalid file path
+    get_inout_hl.email_list = get_data
+    with pytest.raises(ValueError):
+        main.write_output_data(get_inout_hl, tmpdir)
+
+    # non-empty file
+    outpath = tmp_path / "test_output.csv"
+    with open(outpath, "w", encoding="utf-8") as f:
+        f.write("test")
+    with pytest.raises(ValueError):
+        main.write_output_data(get_inout_hl, outpath)

--- a/mailcom/test/test_main.py
+++ b/mailcom/test/test_main.py
@@ -23,6 +23,86 @@ def test_get_input_handler_dir(tmpdir):
         main.get_input_handler(indir, in_type="dir")
 
 
+def test_is_valid_settings():
+    settings = {"default_lang": 1}
+    assert main.is_valid_settings(settings) is False
+    settings = {"default_lang": "fr"}
+    assert main.is_valid_settings(settings) is True
+    settings = {"default_lang": "unknown"}
+    assert main.is_valid_settings(settings) is True
+    settings = {"default_lang": ""}
+    assert main.is_valid_settings(settings) is True
+
+    settings = {"datetime_detection": True}
+    assert main.is_valid_settings(settings) is True
+    settings = {"datetime_detection": "test"}
+    assert main.is_valid_settings(settings) is False
+
+    settings = {"time_parsing": "strict"}
+    assert main.is_valid_settings(settings) is True
+    settings = {"time_parsing": "unknown"}
+    assert main.is_valid_settings(settings) is False
+
+    settings = {"pseudo_emailaddresses": True}
+    assert main.is_valid_settings(settings) is True
+    settings = {"pseudo_emailaddresses": "test"}
+    assert main.is_valid_settings(settings) is False
+
+    settings = {"pseudo_ne": False}
+    assert main.is_valid_settings(settings) is True
+    settings = {"pseudo_ne": "test"}
+    assert main.is_valid_settings(settings) is False
+
+    settings = {"pseudo_numbers": True}
+    assert main.is_valid_settings(settings) is True
+    settings = {"pseudo_numbers": "test"}
+    assert main.is_valid_settings(settings) is False
+
+    settings = {"pseudo_first_names": "test"}
+    assert main.is_valid_settings(settings) is False
+    settings = {"pseudo_first_names": []}
+    assert main.is_valid_settings(settings) is False
+    settings = {"pseudo_first_names": {}}
+    assert main.is_valid_settings(settings) is False
+    settings = {"pseudo_first_names": {"test": "test"}}
+    assert main.is_valid_settings(settings) is True
+    settings = {"pseudo_first_names": {"test": "test", "test2": "test2"}}
+    assert main.is_valid_settings(settings) is True
+
+    settings = {"lang_detection_lib": "langid"}
+    assert main.is_valid_settings(settings) is True
+    settings = {"lang_detection_lib": "unknown"}
+    assert main.is_valid_settings(settings) is False
+
+    settings = {"lang_pipeline": None}
+    assert main.is_valid_settings(settings) is True
+    settings = {"lang_pipeline": "unknown"}
+    assert main.is_valid_settings(settings) is False
+    settings = {"lang_pipeline": {}}
+    assert main.is_valid_settings(settings) is False
+    settings = {"lang_pipeline": {"test": "test"}}
+    assert main.is_valid_settings(settings) is False
+    settings = {"lang_pipeline": {"task": "test"}}
+    assert main.is_valid_settings(settings) is False
+    settings = {"lang_pipeline": {"model": "test"}}
+    assert main.is_valid_settings(settings) is False
+    settings = {"lang_pipeline": {"task": "test", "model": "test"}}
+    assert main.is_valid_settings(settings) is True
+
+    settings = {"spacy_model": "test"}
+    assert main.is_valid_settings(settings) is True
+    settings = {"spacy_model": {}}
+    assert main.is_valid_settings(settings) is False
+
+    settings = {"ner_pipeline": None}
+    assert main.is_valid_settings(settings) is True
+    settings = {"ner_pipeline": "unknown"}
+    assert main.is_valid_settings(settings) is False
+
+    settings = {"unknown_key": "value"}
+    assert main.is_valid_settings(settings) is False
+
+
 def test_get_workflow_settings(tmp_path):
     setting_path = tmp_path / "settings.json"
     with pytest.raises(FileNotFoundError):

--- a/mailcom/test/test_main.py
+++ b/mailcom/test/test_main.py
@@ -99,7 +99,7 @@ def test_process_data_default(get_data, get_settings, get_inout_hl):
 
 
 def test_process_data_no_lang(get_data, get_settings, get_inout_hl):
-    get_settings["pseudonymize"]["default_lang"] = "de"
+    get_settings["default_lang"] = "de"
     get_inout_hl.email_list = get_data
     main.process_data(get_inout_hl.get_email_list(), get_settings)
 
@@ -123,7 +123,7 @@ def test_process_data_no_lang(get_data, get_settings, get_inout_hl):
 
 
 def test_process_data_no_datetime(get_data, get_settings, get_inout_hl):
-    get_settings["pseudonymize"]["datetime_detection"] = False
+    get_settings["datetime_detection"] = False
     get_inout_hl.email_list = get_data
     main.process_data(get_inout_hl.get_email_list(), get_settings)
 
@@ -140,7 +140,7 @@ def test_process_data_no_datetime(get_data, get_settings, get_inout_hl):
 
 
 def test_process_data_no_email(get_data, get_settings, get_inout_hl):
-    get_settings["pseudonymize"]["pseudo_emailaddresses"] = False
+    get_settings["pseudo_emailaddresses"] = False
     get_inout_hl.email_list = get_data
     main.process_data(get_inout_hl.get_email_list(), get_settings)
 
@@ -154,7 +154,7 @@ def test_process_data_no_email(get_data, get_settings, get_inout_hl):
 
 
 def test_process_data_no_ne(get_data, get_settings, get_inout_hl):
-    get_settings["pseudonymize"]["pseudo_ne"] = False
+    get_settings["pseudo_ne"] = False
     get_inout_hl.email_list = get_data
     main.process_data(get_inout_hl.get_email_list(), get_settings)
 
@@ -176,7 +176,7 @@ def test_process_data_no_ne(get_data, get_settings, get_inout_hl):
 
 
 def test_process_data_no_numbers(get_data, get_settings, get_inout_hl):
-    get_settings["pseudonymize"]["pseudo_numbers"] = False
+    get_settings["pseudo_numbers"] = False
     get_inout_hl.email_list = get_data
     main.process_data(get_inout_hl.get_email_list(), get_settings)
 

--- a/mailcom/test/test_main.py
+++ b/mailcom/test/test_main.py
@@ -5,15 +5,39 @@ from mailcom.inout import InoutHandler
 import json
 from pathlib import Path
 from importlib import resources
+import csv
 
 
-def test_get_input_handler_csv(tmp_path):
+def test_get_input_handler_csv_empty(tmp_path):
     inpath = tmp_path / "test.csv"
     with open(inpath, "w", newline="", encoding="utf-8"):
         pass  # empty file
 
     inout_hl = main.get_input_handler(inpath, in_type="csv")
     assert inout_hl.email_list == []
+
+
+def test_get_input_handler_csv_unmatch(tmp_path):
+    inpath = tmp_path / "test.csv"
+    with open(inpath, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        writer.writerow(["no", "content"])
+        writer.writerow(
+            [
+                "1",
+                "Content of test email 1",
+            ]
+        )
+
+    inout_hl = main.get_input_handler(
+        inpath, in_type="csv", col_names=["nonexisting"], unmatched_keyword="unmatched"
+    )
+    emails = inout_hl.get_email_list()
+    email = next(emails)
+    assert email["content"] == "unmatched"
+    assert email["date"] is None
+    assert email["attachment"] is None
+    assert email["attachement type"] is None
 
 
 def test_get_input_handler_dir(tmpdir):
@@ -24,6 +48,11 @@ def test_get_input_handler_dir(tmpdir):
 
 
 def test_is_valid_settings():
+    settings = {"csv_col_unmatched_keyword": True}
+    assert main.is_valid_settings(settings) is False
+    settings = {"csv_col_unmatched_keyword": "error"}
+    assert main.is_valid_settings(settings) is True
+
     settings = {"default_lang": 1}
     assert main.is_valid_settings(settings) is False
     settings = {"default_lang": "fr"}
@@ -277,8 +306,19 @@ def test_process_data_no_numbers(get_data, get_settings, get_inout_hl):
 
 
 def test_process_data_empty_email(get_data, get_settings, get_inout_hl):
+    # no content key
     get_inout_hl.email_list = get_data
     get_inout_hl.email_list.append({"no-content": "test"})
+    main.process_data(get_inout_hl.get_email_list(), get_settings)
+    emails = get_inout_hl.get_email_list()
+    next(emails)
+    next(emails)
+    email_3 = next(emails)
+    assert "pseudo_content" not in email_3
+
+    # unmatched content
+    get_inout_hl.email_list = get_data
+    get_inout_hl.email_list.append({"content": "unmatched"})
     main.process_data(get_inout_hl.get_email_list(), get_settings)
     emails = get_inout_hl.get_email_list()
     next(emails)
@@ -339,9 +379,21 @@ def test_write_output_data_invalid(get_data, tmp_path, get_inout_hl, tmpdir):
     with pytest.raises(ValueError):
         main.write_output_data(get_inout_hl, tmpdir)
 
-    # non-empty file
+    # non-empty file, non-overwrite
     outpath = tmp_path / "test_output.csv"
     with open(outpath, "w", encoding="utf-8") as f:
         f.write("test")
     with pytest.raises(ValueError):
         main.write_output_data(get_inout_hl, outpath)
+
+
+def test_write_output_data_overwrite(get_data, tmp_path, get_inout_hl):
+    # non-empty file, overwrite
+    outpath = tmp_path / "test_output.csv"
+    with open(outpath, "w", encoding="utf-8") as f:
+        f.write("test")
+    get_inout_hl.email_list = get_data
+    main.write_output_data(get_inout_hl, outpath, overwrite=True)
+    with open(outpath, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+        assert len(lines) == 3  # header + 2 emails

--- a/notebook/demo.ipynb
+++ b/notebook/demo.ipynb
@@ -83,27 +83,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below, the input files are loaded from the given `input_dir` directory into an input handler. You can provide relative or absolute paths to the directory that contains your `eml` or `html` files. All files of the `eml` or `html` file type in that directory will be considered input files.\n",
-    "\n",
-    "Each `eml` or `html` file will be stored in an email dictionary."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# import files from input_dir - change this to your own directory\n",
-    "input_dir = \"../data/in/\"\n",
-    "input_handler = mailcom.get_input_handler(in_path=input_dir, in_type=\"dir\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "All settings for the whole pseudonymize process are stored in the file `mailcom/settings.json`. You can adjust them if necessary and load them before executing the pseudonymize feature."
+    "All settings for the whole pseudonymize process are stored in the file `mailcom/settings.json`. You can adjust them if necessary and load them before other steps."
    ]
   },
   {
@@ -115,6 +95,64 @@
     "# get workflow settings\n",
     "setting_path = \"../mailcom/settings.json\"\n",
     "workflow_settings = mailcom.get_workflow_settings(setting_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We currently support two types of input data: (1) `csv`file and (2) directory of `eml` and `html` files.\n",
+    "\n",
+    "Each row of the `csv`file, `eml` file, or `html` file will be stored in an email dictionary, with pre-defined keys: `content`, `date`, `attachment`, and `attachement type`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When loading a `csv`file as an input, a list of columns in the file to map with the above pre-defined keys should be provided. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import data from a csv file - change this to your own file\n",
+    "input_csv = \"../data/mails_lb_sg.csv\"\n",
+    "unmatched_keyword = workflow_settings.get(\"csv_col_unmatched_keyword\")\n",
+    "input_handler = mailcom.get_input_handler(in_path=input_csv, in_type=\"csv\", \n",
+    "                                          col_names=[\"message\"], \n",
+    "                                          init_data_fields=[\"content\"], \n",
+    "                                          unmatched_keyword=unmatched_keyword)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the cell above, the `message` column from the `csv` file is mapped to the `content` key in the email dictionary, while other keys have `None` as their values.\n",
+    "\n",
+    "If the `csv` file lacks the `message` column, value of `content` is set to `unmatched_keyword`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below, the input files are loaded from the given `input_dir` directory into an input handler. You can provide relative or absolute paths to the directory that contains your `eml` or `html` files. All files of the `eml` or `html` file type in that directory will be considered input files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import files from input_dir - change this to your own directory\n",
+    "input_dir = \"../data/in/\"\n",
+    "input_handler = mailcom.get_input_handler(in_path=input_dir, in_type=\"dir\")"
    ]
   },
   {
@@ -191,13 +229,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mailcom.write_output_data(input_handler, \"../data/out/out_demo.csv\")"
+    "# set overwrite to True to overwrite the existing file\n",
+    "mailcom.write_output_data(input_handler, \"../data/out/out_demo.csv\", overwrite=True)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "test-mailcom",
+   "display_name": "mailcom",
    "language": "python",
    "name": "python3"
   },
@@ -211,7 +250,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/notebook/performance_demo.ipynb
+++ b/notebook/performance_demo.ipynb
@@ -6,7 +6,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import mailcom.inout\n",
     "import mailcom.parse\n",
     "import pandas as pd\n",
     "import time\n",

--- a/notebook/performance_demo.ipynb
+++ b/notebook/performance_demo.ipynb
@@ -37,7 +37,6 @@
     "# get workflow settings\n",
     "setting_path = \"../mailcom/settings.json\"\n",
     "workflow_settings = mailcom.main.get_workflow_settings(setting_path)\n",
-    "settings = workflow_settings.get(\"pseudonymize\", {})\n",
     "\n",
     "# use default settings\n",
     "# i.e. enable all steps\n",
@@ -45,16 +44,16 @@
     "pseudo_emailaddresses = True\n",
     "pseudo_ne = True\n",
     "pseudo_numbers = True\n",
-    "pseudo_first_names = settings.get(\"pseudo_first_names\", {})\n",
+    "pseudo_first_names = workflow_settings.get(\"pseudo_first_names\", {})\n",
     "lang_lib = \"langid\"\n",
     "lang_pipeline = None\n",
     "spacy_model = \"default\"\n",
     "ner_pipeline = None\n",
     "\n",
     "out_file = \"../data/out/performance_demo.csv\"\n",
-    "in_file = \"../mailcom/test/data_extended/mails_lb_sg.csv\"\n",
+    "in_file = \"../data/mails_lb_sg.csv\"\n",
     "# import data from csv file\n",
-    "email_list = pd.read_csv(\"../data/mails_lb_sg.csv\")\n",
+    "email_list = pd.read_csv(in_file)\n",
     "\n",
     "t_csv_read = time.time()\n",
     "\n",
@@ -196,7 +195,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "test-mailcom",
+   "display_name": "mailcom",
    "language": "python",
    "name": "python3"
   },
@@ -210,7 +209,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Related issue: #70 

**Note: there are two `TODO` in `inout.py` to mark points for discussion before merging.**

* add json schema for the setting file
* add a validation function for the setting file, which will be use in the next PR (issue #71)
* modify `validate_data` method in `inout.py` to validate `email_dict`
    * An `InoutHandler` instance is now created with a list of initial data field (`init_data_fields`)
    * Fields that cannot be extracted from the data will have `None` as their values
* update `load_csv` method in `inout.py` to map columns to `init_data_fields`
    * if a column name is invalid, value of the corresponding field is set to `unmatched_keyword` (specified in setting file)
        * An usage example is described in `demo.ipynb`
    * fields in `init_data_fields` without a matching column are set to `None`
* update `process_data` function in `main.py` to skip email with `None` or `unmatched` content
* update `write_output_data` function in `main.py` to handle writing to a non-empty file
* update `demo.ipynb` accordingly