### PR TITLE
Test Python versions for all OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies and package
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
+        pip install --prefer-binary -e .
 
     - name: Install pytest
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     - name: Install dependencies and package
       run: |
         python -m pip install --upgrade pip
+        pip install setuptools wheel 
         pip install blis
         pip install --prefer-binary -e .
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [windows-latest]
-        python-version: ['3.9']
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: false
     steps:
     - name: Set up Python ${{ matrix.python-version }}
@@ -22,10 +22,8 @@ jobs:
         BLIS_ARCH: generic
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel 
         pip install spacy --no-binary blis
         pip install -e .
-
     - name: Install pytest
       run: |
         pip install pytest pytest-cov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: 'x64'
     - name: Getting repository
       uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python-version: ['3.10', '3.11']
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,12 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install dependencies and package
+      env:
+        BLIS_ARCH: generic
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel 
-        BLIS_ARCH="generic" pip install spacy --no-binary blis
+        pip install spacy --no-binary blis
         pip install -e .
 
     - name: Install pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.13']
       fail-fast: false
     steps:
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+      fail-fast: false
     steps:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel 
-        pip install blis
-        pip install --prefer-binary -e .
+        BLIS_ARCH="generic" pip install spacy --no-binary blis
+        pip install -e .
 
     - name: Install pytest
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        os: [windows-latest]
+        python-version: ['3.9']
       fail-fast: false
     steps:
     - name: Set up Python ${{ matrix.python-version }}
@@ -20,6 +20,7 @@ jobs:
     - name: Install dependencies and package
       run: |
         python -m pip install --upgrade pip
+        if [ "$RUNNER_OS" != "Windows" ]; then pip install blis; fi
         pip install --prefer-binary -e .
 
     - name: Install pytest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
       run: python -m pytest -svv --cov=mailcom --cov-report=xml:mailcom/coverage_re/coverage.xml
 
     - name: Upload coverage reports to Codecov
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
       uses: codecov/codecov-action@v4.0.1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,14 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: false
     steps:
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-
+        architecture: 'x64'
     - name: Getting repository
       uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies and package
       run: |
         python -m pip install --upgrade pip
-        if [ "$RUNNER_OS" != "Windows" ]; then pip install blis; fi
+        pip install blis
         pip install --prefer-binary -e .
 
     - name: Install pytest

--- a/mailcom/inout.py
+++ b/mailcom/inout.py
@@ -143,7 +143,7 @@ class InoutHandler:
         if not text:
             raise ValueError("The text to be written is empty")
 
-        with open(outfile, "w") as file:
+        with open(outfile, "w", encoding="utf-8") as file:
             file.write(text)
 
     def write_csv(self, outfile: str):

--- a/mailcom/test/test_lang_detector.py
+++ b/mailcom/test/test_lang_detector.py
@@ -1,8 +1,16 @@
+# -*- coding: utf-8 -*-
 import pytest
 import math
+import sys
+import io
 from mailcom.lang_detector import LangDetector
 from string import punctuation
 from mailcom.utils import TransformerLoader
+
+# Ensure UTF-8 output on Windows
+if sys.platform.startswith("win"):
+    sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding="utf-8", errors="replace")
+    sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding="utf-8", errors="replace")
 
 
 # test cases for email language detection
@@ -473,7 +481,13 @@ def test_detect_mixed_lang_with_langdetect(get_lang_detector, get_mixed_lang_doc
         if not wrong_detect_second_lang and len(detections) > 1:
             assert detections[1][0] == get_mixed_lang_docs[doc][1]
             assert detections[1][1] > MULTI_DETECT_THRESHOLD
-    print(" ".join(incomplete_detec))
+    # Handle Unicode characters properly for Windows compatibility
+    try:
+        print(" ".join(incomplete_detec))
+    except UnicodeEncodeError:
+        print(
+            " ".join(incomplete_detec).encode("utf-8", errors="replace").decode("utf-8")
+        )
 
 
 @pytest.mark.langdet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "mailcom"
 license = {text = "MIT License"}
 readme = "README.md"
 description = "Pseudonymize email content in Romance languages"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
- identify valid Python and OS versions
- closes #69 
- the dependencies in the paper are listed as follows:

python $\geq$ 3.9, spacy $\geq$ 3.8.5, transformers $\geq$ 4.51.3, eml-parser $\geq$ 2.0.0, bs4 $\geq$ 0.0.2, dicttoxml $\geq$ 1.7.16, torch $\geq$ 2.6.0, pandas $\geq$ 2.2.3, jupyter $\geq$ 1.1.1, matplotlib $\geq$ 3.10.1, langid $\geq$ 1.1.6, langdetect $\geq$ 1.0.9, dateparser $\geq$ 1.2.1, accelerate $\geq$ 1.6.0

In fact, we are only restricted by python $\geq$ 3.9, all the other dependencies should naturally resolve (and we can check that the mentioned version numbers are the correct lowest version numbers with Python 3.9), but I think we should provide compatibility only as python $\geq$ 3.9.