### PR TITLE
amend to PR #98

### DIFF
--- a/.github/ISSUE_TEMPLATES/bug.md
+++ b/.github/ISSUE_TEMPLATES/bug.md
@@ -1,0 +1,37 @@
+---
+name: Bug issue
+about: Use this template for reporting bugs.
+title: "Bug report"
+---
+# Bug report
+
+## Describe the bug
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+## Expected behavior
+A clear and concise description of what you expected to happen.
+
+## Priority
+What is the impact of this bug on the user, how critical is to fix? P0, P1 .. P4
+[Reference - Google Issue tracker priority levels](https://developers.google.com/issue-tracker/concepts/issues#priority)
+
+## Screenshots/Video
+If applicable, add screenshots/video to help explain your problem.
+Remember to mark the area in the application thats impacted.
+
+## Environment
+ - OS: [e.g. iOS]
+ - Version [e.g. 22]
+ - Python version [e.g. 3.13]
+ - dependency versions [e.g. spaCy=3.8.2, transformers=4.46.3, ...]
+
+ ## Execution environment
+ - ie. conda environment + jupyter notebook/Python terminal
+
+## Additional context
+Add any other context about the problem here.
+
+## Additional data
+Add any input data or scripts that reproduce the issue.

--- a/.github/ISSUE_TEMPLATES/bug.md
+++ b/.github/ISSUE_TEMPLATES/bug.md
@@ -19,7 +19,7 @@ What is the impact of this bug on the user, how critical is to fix? P0, P1 .. P4
 
 ## Screenshots/Video
 If applicable, add screenshots/video to help explain your problem.
-Remember to mark the area in the application thats impacted.
+Remember to mark the area in the application that is impacted.
 
 ## Environment
  - OS: [e.g. iOS]

--- a/.github/ISSUE_TEMPLATES/config.yml
+++ b/.github/ISSUE_TEMPLATES/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATES/feature.md
+++ b/.github/ISSUE_TEMPLATES/feature.md
@@ -9,6 +9,7 @@ title: "Feature request"
 A clear and concise description of what the feature is.
 
 ## To Implement
+Describe the steps, requirements, or technical details needed to implement this feature. Include any relevant code snippets, dependencies, or design considerations.
 
 ## Expected behavior
 A clear and concise description of what you expect to happen.

--- a/.github/ISSUE_TEMPLATES/feature.md
+++ b/.github/ISSUE_TEMPLATES/feature.md
@@ -1,0 +1,20 @@
+---
+name: Feature request issue
+about: Use this template for requesting features.
+title: "Feature request"
+---
+# Feature request
+
+## Describe the feature
+A clear and concise description of what the feature is.
+
+## To Implement
+
+## Expected behavior
+A clear and concise description of what you expect to happen.
+
+## Additional context
+Provide an example input and example output for your feature request.
+
+## Impact
+Describe what the new feature will enable users to do.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Set up Python 3.10
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.13"
       - name: install pypa/build
         run: >-
             python -m

--- a/mailcom/__init__.py
+++ b/mailcom/__init__.py
@@ -7,7 +7,10 @@ from mailcom.main import (
 )
 from mailcom.utils import highlight_ne_sent
 
-__version__ = metadata.version("mailcom")
+try:
+    __version__ = metadata.version("mailcom")
+except metadata.PackageNotFoundError:
+    __version__ = "development"
 
 __all__ = [
     "get_input_handler",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
   { name="Felix Fleischle", email="ssc@iwr.uni-heidelberg.de" },
   { name="Thore Olthoff", email="ssc@iwr.uni-heidelberg.de" },
 ]
-version = "0.1.1"
+dynamic = ["version"]
 
 dependencies = [
   "spacy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -56,3 +56,6 @@ markers = [
     "langdet: marks tests related to language detection",
     "datelib : marks tests related to date library",
 ]
+
+[tool.hatch.version]
+source = "vcs"


### PR DESCRIPTION
- amending the previous PR, since the issue templates do not show up. It is possible the `config.yml` is now mandatory with the [new GitHub settings for issue templates] (https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository). Not sure how to test this though while it is not merged with main.