### PR TITLE
detect email addresses using regex

### DIFF
--- a/mailcom/parse.py
+++ b/mailcom/parse.py
@@ -23,6 +23,16 @@ class Pseudonymize:
 
         self.spacy_loader = spacy_loader
 
+        # use regex to find email addresses
+        # local_part@domain.extension
+        # local_part: letters, numbers, . _ % + -
+        # domain: letters, numbers, . -
+        # extension: letters, at least 2 characters
+        # boundary \b to ensure we match whole email addresses only
+        self.email_regex = re.compile(
+            r"\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b"
+        )
+
     def init_spacy(self, language: str, model="default"):
         """Initializes spacy model.
 
@@ -346,7 +356,8 @@ class Pseudonymize:
         return "".join(new_list)
 
     def pseudonymize_email_addresses(self, sentence: str):
-        """Replaces words containing @ in a String with placeholder.
+        """Replaces email addresses in a sentence with placeholder.
+        Email addresses are identified using a regex pattern.
 
         Args:
             sentence (str): Sentence to search for emails.
@@ -357,13 +368,7 @@ class Pseudonymize:
         if "@" not in sentence:
             return sentence
 
-        # use regex to find email addresses
-        # username@domain.extension
-        # username: letters, numbers, . _ % + -
-        # domain: letters, numbers, . -
-        # extension: letters, at least 2 characters
-        pattern = r"\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b"
-        return re.sub(pattern, "[email]", sentence)
+        return self.email_regex.sub("[email]", sentence)
 
     def concatenate(self, sentences: list[str]):
         """Concatenates a list of sentences to a coherent text.

--- a/mailcom/parse.py
+++ b/mailcom/parse.py
@@ -354,14 +354,13 @@ class Pseudonymize:
         Returns:
             str: Text with emails replaced by placeholder.
         """
-        split = re.split(r"\s+", sentence)  # split by any whitespace
-        new_list = []
-        for word in split:
-            if "@" in word:
-                new_list.append("[email]")
-            else:
-                new_list.append(word)
-        return " ".join(new_list)
+        # use regex to find email addresses
+        # username@domain.extension
+        # username: letters, numbers, . _ % + -
+        # domain: letters, numbers, . -
+        # extension: letters, at least 2 characters
+        pattern = r"\b[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}\b"
+        return re.sub(pattern, "[email]", sentence)
 
     def concatenate(self, sentences: list[str]):
         """Concatenates a list of sentences to a coherent text.

--- a/mailcom/parse.py
+++ b/mailcom/parse.py
@@ -354,6 +354,9 @@ class Pseudonymize:
         Returns:
             str: Text with emails replaced by placeholder.
         """
+        if "@" not in sentence:
+            return sentence
+
         # use regex to find email addresses
         # username@domain.extension
         # username: letters, numbers, . _ % + -

--- a/mailcom/test/test_main.py
+++ b/mailcom/test/test_main.py
@@ -388,7 +388,7 @@ def test_process_data_default(get_data, get_settings, get_inout_hl):
     assert email_1.get("detected_datetime").get("content") == []
     assert (
         email_1.get("pseudo_content")
-        == "Claude [email] viendra au bâtiment à [number]h[number]. "
+        == "Claude ([email]) viendra au bâtiment à [number]h[number]. "
         "Nous nous rendrons ensuite au [location]"
     )
     assert email_1.get("sentences").get("content") == [
@@ -396,7 +396,7 @@ def test_process_data_default(get_data, get_settings, get_inout_hl):
         "Nous nous rendrons ensuite au MeetingPoint",
     ]
     assert email_1.get("sentences_after_email").get("content") == [
-        "Alice [email] viendra au bâtiment à 10h00.",
+        "Alice ([email]) viendra au bâtiment à 10h00.",
         "Nous nous rendrons ensuite au MeetingPoint",
     ]
 
@@ -430,7 +430,7 @@ def test_process_data_no_lang(get_data, get_settings, get_inout_hl):
     assert email_1.get("lang").get("content") == "de"
     assert (
         email_1.get("pseudo_content")
-        == "Mika [email] viendra au bâtiment à [number]h[number]. "
+        == "Mika ([email]) viendra au bâtiment à [number]h[number]. "
         "Nous nous rendrons ensuite au [location]"
     )
 
@@ -485,7 +485,7 @@ def test_process_data_no_ne(get_data, get_settings, get_inout_hl):
 
     assert (
         email_1.get("pseudo_content")
-        == "Alice [email] viendra au bâtiment à [number]h[number]. "
+        == "Alice ([email]) viendra au bâtiment à [number]h[number]. "
         "Nous nous rendrons ensuite au MeetingPoint"
     )
 
@@ -518,7 +518,7 @@ def test_process_data_matching_pseudonym(get_data, get_settings, get_inout_hl):
     assert email_1.get("detected_datetime").get("content") == []
     assert (
         email_1.get("pseudo_content")
-        == "Claude [email] viendra au bâtiment à [number]h[number]. "
+        == "Claude ([email]) viendra au bâtiment à [number]h[number]. "
         "Nous nous rendrons ensuite au [location]"
     )
     assert email_1.get("sentences").get("content") == [
@@ -526,7 +526,7 @@ def test_process_data_matching_pseudonym(get_data, get_settings, get_inout_hl):
         "Nous nous rendrons ensuite au MeetingPoint",
     ]
     assert email_1.get("sentences_after_email").get("content") == [
-        "Alice [email] viendra au bâtiment à 10h00.",
+        "Alice ([email]) viendra au bâtiment à 10h00.",
         "Nous nous rendrons ensuite au MeetingPoint",
     ]
 
@@ -615,7 +615,8 @@ def test_process_data_no_numbers(get_data, get_settings, get_inout_hl):
     email_2 = next(emails)
 
     assert (
-        email_1.get("pseudo_content") == "Claude [email] viendra au bâtiment à 10h00. "
+        email_1.get("pseudo_content")
+        == "Claude ([email]) viendra au bâtiment à 10h00. "
         "Nous nous rendrons ensuite au [location]"
     )
 

--- a/mailcom/test/test_main.py
+++ b/mailcom/test/test_main.py
@@ -315,6 +315,48 @@ def get_data():
     ]
 
 
+@pytest.fixture()
+def get_data_result():
+    return [
+        {
+            "lang": "fr",
+            "detected_datetime": [],
+            "sentences": [
+                "Alice (alice@gmail.com) viendra au bâtiment à 10h00.",
+                "Nous nous rendrons ensuite au MeetingPoint",
+            ],
+            "sentences_after_email": [
+                "Alice ([email]) viendra au bâtiment à 10h00.",
+                "Nous nous rendrons ensuite au MeetingPoint",
+            ],
+            "pseudo_content_fr": "Claude ([email]) viendra au bâtiment à "
+            "[number]h[number]. "
+            "Nous nous rendrons ensuite au [location]",
+            "pseudo_content_de": "Mika ([email]) viendra au bâtiment à "
+            "[number]h[number]. "
+            "Nous nous rendrons ensuite au [location]",
+        },
+        {
+            "lang": "es",
+            "detected_datetime": ["28.03.2025 a las 10:30"],
+            "sentences": [
+                "Esta foto fue tomada por Alice el 28.03.2025 a las 10:30.",
+                "Compruébelo en el archivo adjunto",
+            ],
+            "sentences_after_email": [
+                "Esta foto fue tomada por Alice el 28.03.2025 a las 10:30.",
+                "Compruébelo en el archivo adjunto",
+            ],
+            "pseudo_content_es": "Esta foto fue tomada por José el "
+            "28.03.2025 a las 10:30. "
+            "Compruébelo en el archivo adjunto",
+            "pseudo_content_de": "Esta foto fue tomada por Mika el "
+            "28.03.2025 a las 10:30. "
+            "Compruébelo en el archivo adjunto",
+        },
+    ]
+
+
 def _modify_data(base_data: list, updates: list, remove_indices=None):
     data = copy.deepcopy(base_data)
 
@@ -375,7 +417,7 @@ def get_inout_hl():
     return InoutHandler()
 
 
-def test_process_data_default(get_data, get_settings, get_inout_hl):
+def test_process_data_default(get_data, get_settings, get_inout_hl, get_data_result):
     get_inout_hl.email_list = get_data
     main.process_data(get_inout_hl.get_email_list(), get_settings)
 
@@ -383,42 +425,33 @@ def test_process_data_default(get_data, get_settings, get_inout_hl):
     email_1 = next(emails)
     email_2 = next(emails)
 
+    email_1_result = get_data_result[0]
+    email_2_result = get_data_result[1]
+
     assert email_1.get("cleaned_content") == email_1.get("content")
-    assert email_1.get("lang").get("content") == "fr"
-    assert email_1.get("detected_datetime").get("content") == []
-    assert (
-        email_1.get("pseudo_content")
-        == "Claude ([email]) viendra au bâtiment à [number]h[number]. "
-        "Nous nous rendrons ensuite au [location]"
+    assert email_1.get("lang").get("content") == email_1_result.get("lang")
+    assert email_1.get("detected_datetime").get("content") == email_1_result.get(
+        "detected_datetime"
     )
-    assert email_1.get("sentences").get("content") == [
-        "Alice (alice@gmail.com) viendra au bâtiment à 10h00.",
-        "Nous nous rendrons ensuite au MeetingPoint",
-    ]
-    assert email_1.get("sentences_after_email").get("content") == [
-        "Alice ([email]) viendra au bâtiment à 10h00.",
-        "Nous nous rendrons ensuite au MeetingPoint",
-    ]
+    assert email_1.get("pseudo_content") == email_1_result.get("pseudo_content_fr")
+    assert email_1.get("sentences").get("content") == email_1_result.get("sentences")
+    assert email_1.get("sentences_after_email").get("content") == email_1_result.get(
+        "sentences_after_email"
+    )
 
     assert email_2.get("cleaned_content") == email_2.get("content")
-    assert email_2.get("lang").get("content") == "es"
-    assert email_2.get("detected_datetime").get("content") == ["28.03.2025 a las 10:30"]
-    assert (
-        email_2.get("pseudo_content")
-        == "Esta foto fue tomada por José el 28.03.2025 a las 10:30. "
-        "Compruébelo en el archivo adjunto"
+    assert email_2.get("lang").get("content") == email_2_result.get("lang")
+    assert email_2.get("detected_datetime").get("content") == email_2_result.get(
+        "detected_datetime"
     )
-    assert email_2.get("sentences").get("content") == [
-        "Esta foto fue tomada por Alice el 28.03.2025 a las 10:30.",
-        "Compruébelo en el archivo adjunto",
-    ]
-    assert email_2.get("sentences_after_email").get("content") == [
-        "Esta foto fue tomada por Alice el 28.03.2025 a las 10:30.",
-        "Compruébelo en el archivo adjunto",
-    ]
+    assert email_2.get("pseudo_content") == email_2_result.get("pseudo_content_es")
+    assert email_2.get("sentences").get("content") == email_2_result.get("sentences")
+    assert email_2.get("sentences_after_email").get("content") == email_2_result.get(
+        "sentences_after_email"
+    )
 
 
-def test_process_data_no_lang(get_data, get_settings, get_inout_hl):
+def test_process_data_no_lang(get_data, get_settings, get_inout_hl, get_data_result):
     get_settings["default_lang"] = "de"
     get_inout_hl.email_list = get_data
     main.process_data(get_inout_hl.get_email_list(), get_settings)
@@ -427,19 +460,14 @@ def test_process_data_no_lang(get_data, get_settings, get_inout_hl):
     email_1 = next(emails)
     email_2 = next(emails)
 
+    email_1_result = get_data_result[0]
+    email_2_result = get_data_result[1]
+
     assert email_1.get("lang").get("content") == "de"
-    assert (
-        email_1.get("pseudo_content")
-        == "Mika ([email]) viendra au bâtiment à [number]h[number]. "
-        "Nous nous rendrons ensuite au [location]"
-    )
+    assert email_1.get("pseudo_content") == email_1_result.get("pseudo_content_de")
 
     assert email_2.get("lang").get("content") == "de"
-    assert (
-        email_2.get("pseudo_content")
-        == "Esta foto fue tomada por Mika el 28.03.2025 a las 10:30. "
-        "Compruébelo en el archivo adjunto"
-    )
+    assert email_2.get("pseudo_content") == email_2_result.get("pseudo_content_de")
 
 
 def test_process_data_no_datetime(get_data, get_settings, get_inout_hl):

--- a/mailcom/test/test_parse.py
+++ b/mailcom/test/test_parse.py
@@ -354,11 +354,11 @@ def test_pseudonymize_w_prev_ne_list(get_default_fr):
 def test_pseudonymize_email_addresses(get_default_fr):
     sentence = "My email is example@example.com."
     pseudonymized_sentence = get_default_fr.pseudonymize_email_addresses(sentence)
-    assert pseudonymized_sentence == "My email is [email]"
+    assert pseudonymized_sentence == "My email is [email]."
 
     sentence = "Contact us at support@example.com or sales@example.com."
     pseudonymized_sentence = get_default_fr.pseudonymize_email_addresses(sentence)
-    assert pseudonymized_sentence == "Contact us at [email] or [email]"
+    assert pseudonymized_sentence == "Contact us at [email] or [email]."
 
     sentence = "No email addresses here!"
     pseudonymized_sentence = get_default_fr.pseudonymize_email_addresses(sentence)
@@ -367,6 +367,18 @@ def test_pseudonymize_email_addresses(get_default_fr):
     sentence = ""
     pseudonymized_sentence = get_default_fr.pseudonymize_email_addresses(sentence)
     assert pseudonymized_sentence == ""
+
+
+def test_pseudonymize_email_addresses_special_cases(get_default_fr):
+    sentence = (
+        "Contact my.employee@example.com and admin@test.org, "
+        "but not @username or anotheruser@name"
+    )
+    pseudonymized_sentence = get_default_fr.pseudonymize_email_addresses(sentence)
+    assert (
+        pseudonymized_sentence
+        == "Contact [email] and [email], but not @username or anotheruser@name"
+    )
 
 
 def test_choose_per_pseudonym_new_name(get_default_fr):
@@ -459,6 +471,40 @@ def test_pseudonymize_ne_person_prev_ne_list(get_default_fr):
     assert "Camille" not in pseudonymized_sentence
     assert "Dominique" in pseudonymized_sentence
     assert "Florence" in pseudonymized_sentence
+
+
+def test_pseudonymize_ne_person_special_cases(get_default_fr):
+    sentence = "Veuillez envoyer un courriel à Tobi, @Natasha"
+    ner = [
+        {"entity_group": "PER", "word": "Tobi", "start": 31, "end": 35},
+        {"entity_group": "PER", "word": "Natasha", "start": 38, "end": 45},
+    ]
+    pseudonymized_sentence = " ".join(get_default_fr.pseudonymize_ne(ner, sentence))
+    assert "Tobi" not in pseudonymized_sentence
+    assert "Natasha" not in pseudonymized_sentence
+    assert any(
+        pseudo in pseudonymized_sentence
+        for pseudo in get_default_fr.pseudo_first_names["fr"]
+    )
+
+    sentence = "Veuillez envoyer un courriel à Tobi, @natasha234"
+    ner = [
+        {"entity_group": "PER", "word": "Tobi", "start": 31, "end": 35},
+        {"entity_group": "PER", "word": "natasha234", "start": 38, "end": 45},
+    ]
+    pseudonymized_sentence = " ".join(get_default_fr.pseudonymize_ne(ner, sentence))
+    assert "Tobi" not in pseudonymized_sentence
+    assert "natasha234" not in pseudonymized_sentence
+    assert "234" in pseudonymized_sentence
+
+    sentence = "Veuillez envoyer un courriel à Tobi, @sh.nata"
+    ner = [
+        {"entity_group": "PER", "word": "Tobi", "start": 31, "end": 35},
+        {"entity_group": "PER", "word": "sh.nata", "start": 38, "end": 45},
+    ]
+    pseudonymized_sentence = " ".join(get_default_fr.pseudonymize_ne(ner, sentence))
+    assert "Tobi" not in pseudonymized_sentence
+    assert "sh.nata" not in pseudonymized_sentence
 
 
 def test_pseudonymize_ne_location(get_default_fr):


### PR DESCRIPTION
Detect email addresses with regex instead of masking all words with `@` inside.

Pros:
- detect the exact form of email addresses
- other words with `@`, e.g. `@username`, won't be considered as email addresses
- won't include surrounding punctuations into email addresses, e.g. `myemail@mail.com.` is masked as `[email].` instead of `[email]`

Cons:
- more expensive than simply check `"@" in sentence`
- if a username after `@` could not be recognized by NER, this username would retain in the pseudonymized sentence.